### PR TITLE
Refactoring tracer api

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     paths:
         - src
         - config

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -17,13 +17,10 @@ use OpenTelemetry\Context\ScopeInterface;
  * @method static ScopeInterface|null activeScope()
  * @method static ContextInterface currentContext()
  * @method static array propagationHeaders(?ContextInterface $context = null)
- * @method static SpanBuilderInterface build(string $name)
- * @method static SpanInterface start(string $name, int $spanKind = SpanKind::KIND_INTERNAL)
- * @method static mixed measure(string $name, \Closure $callback)
- * @method static mixed measureAsync(string $name, \Closure $callback)
- * @method static SpanInterface recordExceptionToSpan(SpanInterface $span, \Throwable $exception)
  * @method static Context|null extractContextFromPropagationHeaders(array $headers)
- * @method static void setRootSpan(SpanInterface $span)
+ * @method static SpanBuilderInterface build(string $name)
+ * @method static SpanInterface start(string $name, int $spanKind = SpanKind::KIND_INTERNAL, ?ContextInterface $context = null)
+ * @method static mixed measure(string $name, \Closure $callback, int $spanKind = SpanKind::KIND_INTERNAL)
  */
 class Tracer extends Facade
 {

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -2,10 +2,10 @@
 
 namespace Keepsuit\LaravelOpenTelemetry\Facades;
 
+use Closure;
 use Illuminate\Support\Facades\Facade;
-use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use Keepsuit\LaravelOpenTelemetry\Support\SpanBuilder;
 use OpenTelemetry\API\Trace\SpanInterface;
-use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\Context\ScopeInterface;
@@ -18,9 +18,9 @@ use OpenTelemetry\Context\ScopeInterface;
  * @method static ContextInterface currentContext()
  * @method static array propagationHeaders(?ContextInterface $context = null)
  * @method static Context|null extractContextFromPropagationHeaders(array $headers)
- * @method static SpanBuilderInterface build(string $name)
- * @method static SpanInterface start(string $name, int $spanKind = SpanKind::KIND_INTERNAL, ?ContextInterface $context = null)
- * @method static mixed measure(string $name, \Closure $callback, int $spanKind = SpanKind::KIND_INTERNAL)
+ * @method static SpanBuilder newSpan(string $name)
+ * @method static SpanInterface start(string $name)
+ * @method static mixed measure(string $name, Closure $callback)
  */
 class Tracer extends Facade
 {

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -21,6 +21,7 @@ use OpenTelemetry\Context\ScopeInterface;
  * @method static SpanBuilder newSpan(string $name)
  * @method static SpanInterface start(string $name)
  * @method static mixed measure(string $name, Closure $callback)
+ * @method static void updateLogContext()
  */
 class Tracer extends Facade
 {

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -2,7 +2,6 @@
 
 namespace Keepsuit\LaravelOpenTelemetry\Facades;
 
-use Closure;
 use Illuminate\Support\Facades\Facade;
 use Keepsuit\LaravelOpenTelemetry\Support\SpanBuilder;
 use OpenTelemetry\API\Trace\SpanInterface;
@@ -19,8 +18,6 @@ use OpenTelemetry\Context\ScopeInterface;
  * @method static array propagationHeaders(?ContextInterface $context = null)
  * @method static Context|null extractContextFromPropagationHeaders(array $headers)
  * @method static SpanBuilder newSpan(string $name)
- * @method static SpanInterface start(string $name)
- * @method static mixed measure(string $name, Closure $callback)
  * @method static void updateLogContext()
  */
 class Tracer extends Facade

--- a/src/Instrumentation/QueryInstrumentation.php
+++ b/src/Instrumentation/QueryInstrumentation.php
@@ -29,20 +29,17 @@ class QueryInstrumentation implements Instrumentation
                 default: fn () => ''
             );
 
-        $span = Tracer::build(sprintf('sql %s', $operationName))
+        $span = Tracer::newSpan(sprintf('sql %s', $operationName))
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setStartTimestamp($this->getEventStartTimestampNs($event->time))
+            ->setAttribute(TraceAttributes::DB_SYSTEM, $event->connection->getDriverName())
+            ->setAttribute(TraceAttributes::DB_NAME, $event->connection->getDatabaseName())
+            ->setAttribute(TraceAttributes::DB_OPERATION, $operationName)
+            ->setAttribute(TraceAttributes::DB_STATEMENT, $event->sql)
+            ->setAttribute(TraceAttributes::DB_USER, $event->connection->getConfig('username'))
+            ->setAttribute(TraceAttributes::SERVER_ADDRESS, $event->connection->getConfig('host'))
+            ->setAttribute(TraceAttributes::SERVER_PORT, $event->connection->getConfig('port'))
             ->startSpan();
-
-        $span->setAttributes([
-            TraceAttributes::DB_SYSTEM => $event->connection->getDriverName(),
-            TraceAttributes::DB_NAME => $event->connection->getDatabaseName(),
-            TraceAttributes::DB_OPERATION => $operationName,
-            TraceAttributes::DB_STATEMENT => $event->sql,
-            TraceAttributes::DB_USER => $event->connection->getConfig('username'),
-            TraceAttributes::SERVER_ADDRESS => $event->connection->getConfig('host'),
-            TraceAttributes::SERVER_PORT => $event->connection->getConfig('port'),
-        ]);
 
         $span->end();
     }

--- a/src/Instrumentation/QueryInstrumentation.php
+++ b/src/Instrumentation/QueryInstrumentation.php
@@ -39,7 +39,7 @@ class QueryInstrumentation implements Instrumentation
             ->setAttribute(TraceAttributes::DB_USER, $event->connection->getConfig('username'))
             ->setAttribute(TraceAttributes::SERVER_ADDRESS, $event->connection->getConfig('host'))
             ->setAttribute(TraceAttributes::SERVER_PORT, $event->connection->getConfig('port'))
-            ->startSpan();
+            ->start();
 
         $span->end();
     }

--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -41,6 +41,8 @@ class QueueInstrumentation implements Instrumentation
                 ->startSpan();
 
             $span->activate();
+
+            Tracer::updateLogContext();
         });
     }
 

--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -38,7 +38,7 @@ class QueueInstrumentation implements Instrumentation
                 ->setAttribute('messaging.destination.kind', 'queue')
                 ->setAttribute('messaging.destination.name', $event->job->getQueue())
                 ->setAttribute('messaging.destination.template', $event->job->resolveName())
-                ->startSpan();
+                ->start();
 
             $span->activate();
 

--- a/src/Instrumentation/RedisInstrumentation.php
+++ b/src/Instrumentation/RedisInstrumentation.php
@@ -27,7 +27,7 @@ class RedisInstrumentation implements Instrumentation
     {
         $traceName = sprintf('redis %s %s', $event->connection->getName(), $event->command);
 
-        $span = Tracer::build($traceName)
+        $span = Tracer::newSpan($traceName)
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setStartTimestamp($this->getEventStartTimestampNs($event->time))
             ->startSpan();

--- a/src/Instrumentation/RedisInstrumentation.php
+++ b/src/Instrumentation/RedisInstrumentation.php
@@ -30,7 +30,7 @@ class RedisInstrumentation implements Instrumentation
         $span = Tracer::newSpan($traceName)
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setStartTimestamp($this->getEventStartTimestampNs($event->time))
-            ->startSpan();
+            ->start();
 
         if ($span->isRecording()) {
             $span->setAttribute(TraceAttributes::DB_SYSTEM, 'redis')

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -74,7 +74,7 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
                 ),
             ),
             'http' => new OtlpSpanExporter(
-            // @phpstan-ignore-next-line
+                // @phpstan-ignore-next-line
                 (new OtlpHttpTransportFactory())->create(
                     (new HttpEndpointResolver())->resolveToString(config('opentelemetry.exporters.http.endpoint'), Signals::TRACE),
                     'application/x-protobuf'

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -74,7 +74,7 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
                 ),
             ),
             'http' => new OtlpSpanExporter(
-                // @phpstan-ignore-next-line
+            // @phpstan-ignore-next-line
                 (new OtlpHttpTransportFactory())->create(
                     (new HttpEndpointResolver())->resolveToString(config('opentelemetry.exporters.http.endpoint'), Signals::TRACE),
                     'application/x-protobuf'
@@ -155,5 +155,8 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         $envRepository = Env::getRepository();
 
         $envRepository->set(OTELVariables::OTEL_SERVICE_NAME, config('opentelemetry.service_name'));
+
+        // Disable debug scopes wrapping
+        $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] = 1;
     }
 }

--- a/src/Support/CarbonClock.php
+++ b/src/Support/CarbonClock.php
@@ -4,6 +4,7 @@ namespace Keepsuit\LaravelOpenTelemetry\Support;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 
@@ -19,14 +20,14 @@ class CarbonClock implements ClockInterface
     public function now(): int
     {
         if (Carbon::hasTestNow()) {
-            return (int) CarbonImmutable::now()->getPreciseTimestamp(6) * 1000;
+            return static::carbonToNanos(CarbonImmutable::now());
         }
 
         return $this->systemClock->now();
     }
 
-    public function nanoTime(): int
+    public static function carbonToNanos(CarbonInterface $carbon): int
     {
-        return $this->now();
+        return (int) $carbon->getPreciseTimestamp(6) * 1000;
     }
 }

--- a/src/Support/HttpClient/GuzzleTraceMiddleware.php
+++ b/src/Support/HttpClient/GuzzleTraceMiddleware.php
@@ -17,18 +17,16 @@ class GuzzleTraceMiddleware
     {
         return static function (callable $handler): callable {
             return static function (RequestInterface $request, array $options) use ($handler) {
-                $span = Tracer::build(sprintf('HTTP %s', $request->getMethod()))
+                $span = Tracer::newSpan(sprintf('HTTP %s', $request->getMethod()))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
-                    ->setAttributes([
-                        TraceAttributes::URL_FULL => sprintf('%s://%s%s', $request->getUri()->getScheme(), $request->getUri()->getHost(), $request->getUri()->getPath()),
-                        TraceAttributes::URL_PATH => $request->getUri()->getPath(),
-                        TraceAttributes::URL_QUERY => $request->getUri()->getQuery(),
-                        TraceAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
-                        TraceAttributes::HTTP_REQUEST_BODY_SIZE => $request->getBody()->getSize(),
-                        TraceAttributes::URL_SCHEME => $request->getUri()->getScheme(),
-                        TraceAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
-                        TraceAttributes::SERVER_PORT => $request->getUri()->getPort(),
-                    ])
+                    ->setAttribute(TraceAttributes::URL_FULL, sprintf('%s://%s%s', $request->getUri()->getScheme(), $request->getUri()->getHost(), $request->getUri()->getPath()))
+                    ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
+                    ->setAttribute(TraceAttributes::URL_QUERY, $request->getUri()->getQuery())
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getBody()->getSize())
+                    ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
+                    ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
+                    ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
                     ->startSpan();
 
                 $context = $span->storeInContext(Tracer::currentContext());
@@ -41,10 +39,8 @@ class GuzzleTraceMiddleware
                 assert($promise instanceof PromiseInterface);
 
                 return $promise->then(function (Response $response) use ($span) {
-                    $span->setAttributes([
-                        TraceAttributes::HTTP_RESPONSE_STATUS_CODE => $response->getStatusCode(),
-                        TraceAttributes::HTTP_REQUEST_BODY_SIZE => $response->getHeader('Content-Length')[0] ?? null,
-                    ]);
+                    $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode())
+                        ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $response->getHeader('Content-Length')[0] ?? null);
 
                     if ($response->getStatusCode() >= 400) {
                         $span->setStatus(StatusCode::STATUS_ERROR);

--- a/src/Support/HttpClient/GuzzleTraceMiddleware.php
+++ b/src/Support/HttpClient/GuzzleTraceMiddleware.php
@@ -27,7 +27,7 @@ class GuzzleTraceMiddleware
                     ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
                     ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
                     ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
-                    ->startSpan();
+                    ->start();
 
                 $context = $span->storeInContext(Tracer::currentContext());
 

--- a/src/Support/HttpServer/TraceRequestMiddleware.php
+++ b/src/Support/HttpServer/TraceRequestMiddleware.php
@@ -24,6 +24,8 @@ class TraceRequestMiddleware
         $span = $this->startTracing($request);
         $scope = $span->activate();
 
+        Tracer::updateLogContext();
+
         try {
             $response = $next($request);
 

--- a/src/Support/HttpServer/TraceRequestMiddleware.php
+++ b/src/Support/HttpServer/TraceRequestMiddleware.php
@@ -68,7 +68,7 @@ class TraceRequestMiddleware
             ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->userAgent())
             ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
             ->setAttribute(TraceAttributes::NETWORK_PEER_ADDRESS, $request->ip())
-            ->startSpan();
+            ->start();
     }
 
     protected function recordHttpResponseToSpan(SpanInterface $span, Response $response): void

--- a/src/Support/SpanBuilder.php
+++ b/src/Support/SpanBuilder.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Support;
+
+use Closure;
+use Illuminate\Foundation\Bus\PendingDispatch;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\API\Trace\SpanInterface;
+use Throwable;
+
+class SpanBuilder implements SpanBuilderInterface
+{
+    public function __construct(
+        protected SpanBuilderInterface $spanBuilder
+    ) {
+    }
+
+    public function setParent($context): SpanBuilder
+    {
+        $this->spanBuilder->setParent($context);
+
+        return $this;
+    }
+
+    public function addLink(SpanContextInterface $context, iterable $attributes = []): SpanBuilder
+    {
+        $this->spanBuilder->addLink($context, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * @param  mixed  $value
+     */
+    public function setAttribute(string $key, $value): SpanBuilder
+    {
+        $this->spanBuilder->setAttribute($key, $value);
+
+        return $this;
+    }
+
+    public function setAttributes(iterable $attributes): SpanBuilder
+    {
+        $this->spanBuilder->setAttributes($attributes);
+
+        return $this;
+    }
+
+    public function setStartTimestamp(int $timestampNanos): SpanBuilder
+    {
+        $this->spanBuilder->setStartTimestamp($timestampNanos);
+
+        return $this;
+    }
+
+    public function setSpanKind(int $spanKind): SpanBuilder
+    {
+        $this->spanBuilder->setSpanKind($spanKind);
+
+        return $this;
+    }
+
+    public function startSpan(): SpanInterface
+    {
+        return $this->spanBuilder->startSpan();
+    }
+
+    /**
+     * @template U
+     *
+     * @param  Closure(SpanInterface $span): U  $callback
+     * @return U
+     *
+     * @throws Throwable
+     */
+    public function measure(Closure $callback): mixed
+    {
+        $span = $this->startSpan();
+        $scope = $span->activate();
+
+        try {
+            $result = $callback($span);
+
+            // Fix: Dispatch is effective only on destruct
+            if ($result instanceof PendingDispatch) {
+                $result = null;
+            }
+
+            return $result;
+        } catch (Throwable $exception) {
+            $span->recordException($exception);
+
+            throw $exception;
+        } finally {
+            $span->end();
+            $scope->detach();
+        }
+    }
+}

--- a/src/Support/SpanBuilder.php
+++ b/src/Support/SpanBuilder.php
@@ -70,7 +70,7 @@ class SpanBuilder implements SpanBuilderInterface
      * @template U
      *
      * @param  Closure(SpanInterface $span): U  $callback
-     * @return U
+     * @return (U is PendingDispatch ? null : U)
      *
      * @throws Throwable
      */

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -43,9 +43,9 @@ class Tracer
      *
      * @param  non-empty-string  $name
      * @param  Closure(SpanInterface $span): U  $callback
+     * @throws \Throwable
      * @return (U is PendingDispatch ? null : U)
      *
-     * @throws \Throwable
      */
     public function measure(string $name, Closure $callback)
     {
@@ -101,14 +101,14 @@ class Tracer
         return false;
     }
 
-    //    protected function setTraceIdForLogs(SpanInterface $span): void
-    //    {
-    //        if (config('opentelemetry.logs.inject_trace_id', true)) {
-    //            $field = config('opentelemetry.logs.trace_id_field', 'traceId');
-    //
-    //            Log::shareContext([
-    //                $field => $span->getContext()->getTraceId(),
-    //            ]);
-    //        }
-    //    }
+    public function updateLogContext(): void
+    {
+        if (config('opentelemetry.logs.inject_trace_id', true)) {
+            $field = config('opentelemetry.logs.trace_id_field', 'traceId');
+
+            Log::shareContext([
+                $field => $this->traceId(),
+            ]);
+        }
+    }
 }

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -3,6 +3,7 @@
 namespace Keepsuit\LaravelOpenTelemetry;
 
 use Closure;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Log;
 use Keepsuit\LaravelOpenTelemetry\Support\SpanBuilder;
 use OpenTelemetry\API\Trace\SpanInterface;
@@ -42,7 +43,7 @@ class Tracer
      *
      * @param  non-empty-string  $name
      * @param  Closure(SpanInterface $span): U  $callback
-     * @return U
+     * @return (U is PendingDispatch ? null : U)
      *
      * @throws \Throwable
      */

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -43,9 +43,9 @@ class Tracer
      *
      * @param  non-empty-string  $name
      * @param  Closure(SpanInterface $span): U  $callback
-     * @throws \Throwable
      * @return (U is PendingDispatch ? null : U)
      *
+     * @throws \Throwable
      */
     public function measure(string $name, Closure $callback)
     {

--- a/tests/Instrumentation/HttpClientInstrumentationTest.php
+++ b/tests/Instrumentation/HttpClientInstrumentationTest.php
@@ -21,7 +21,7 @@ it('injects propagation headers to Http client request', function () {
         new Response(200, ['Content-Length' => 0]),
     ]);
 
-    $root = Tracer::start('root');
+    $root = Tracer::newSpan('root')->start();
     $scope = $root->activate();
 
     Http::withTrace()->get(Server::$url);

--- a/tests/Instrumentation/HttpServerInstrumentationTest.php
+++ b/tests/Instrumentation/HttpServerInstrumentationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Instrumentation\HttpServerInstrumentation;
@@ -46,6 +47,10 @@ it('can trace a request', function () {
             'http.response.status_code' => 200,
             'http.response.body.size' => 32,
         ]);
+
+    expect(Log::sharedContext())->toMatchArray([
+        'traceId' => $traceId,
+    ]);
 });
 
 it('can record route exception', function () {

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -5,7 +5,6 @@ use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Tests\Support\TestJob;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\SDK\Trace\Span;
 use Spatie\Valuestore\Valuestore;
 
 beforeEach(function () {

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -42,5 +42,6 @@ it('can trace queue jobs', function () {
 
     expect($this->valuestore)
         ->get('traceparentInJob')->toBe(sprintf('00-%s-%s-01', $traceId, $spanId))
-        ->get('traceIdInJob')->toBe($traceId);
+        ->get('traceIdInJob')->toBe($traceId)
+        ->get('logContextInJob')->toMatchArray(['traceId' => $traceId]);
 });

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -19,14 +19,14 @@ it('can trace queue jobs', function () {
     $spanId = '';
     $traceId = '';
 
-    Tracer::measure('dispatcher', function (Span $span) use (&$traceId, &$spanId) {
-        $spanId = $span->getContext()->getSpanId();
-        $traceId = $span->getContext()->getTraceId();
+    Tracer::newSpan('dispatcher')
+        ->setSpanKind(SpanKind::KIND_PRODUCER)
+        ->measure(function (Span $span) use (&$traceId, &$spanId) {
+            $spanId = $span->getContext()->getSpanId();
+            $traceId = $span->getContext()->getTraceId();
 
-        return dispatch(new TestJob($this->valuestore));
-    },
-        spanKind: SpanKind::KIND_PRODUCER
-    );
+            return dispatch(new TestJob($this->valuestore));
+        });
 
     expect($traceId)
         ->not->toBeEmpty()

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Artisan;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Tests\Support\TestJob;
+use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\SDK\Trace\Span;
 use Spatie\Valuestore\Valuestore;
@@ -21,7 +22,7 @@ it('can trace queue jobs', function () {
 
     Tracer::newSpan('dispatcher')
         ->setSpanKind(SpanKind::KIND_PRODUCER)
-        ->measure(function (Span $span) use (&$traceId, &$spanId) {
+        ->measure(function (SpanInterface $span) use (&$traceId, &$spanId) {
             $spanId = $span->getContext()->getSpanId();
             $traceId = $span->getContext()->getTraceId();
 

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Artisan;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Tests\Support\TestJob;
+use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\SDK\Trace\Span;
 use Spatie\Valuestore\Valuestore;
 
@@ -18,12 +19,14 @@ it('can trace queue jobs', function () {
     $spanId = '';
     $traceId = '';
 
-    Tracer::measureAsync('dispatcher', function (Span $span) use (&$traceId, &$spanId) {
+    Tracer::measure('dispatcher', function (Span $span) use (&$traceId, &$spanId) {
         $spanId = $span->getContext()->getSpanId();
         $traceId = $span->getContext()->getTraceId();
 
-        dispatch(new TestJob($this->valuestore));
-    });
+        return dispatch(new TestJob($this->valuestore));
+    },
+        spanKind: SpanKind::KIND_PRODUCER
+    );
 
     expect($traceId)
         ->not->toBeEmpty()

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -30,7 +30,7 @@ function getRecordedSpans(): array
 
 function withRootSpan(Closure $callback): mixed
 {
-    $rootSpan = \Keepsuit\LaravelOpenTelemetry\Facades\Tracer::newSpan('root')->startSpan();
+    $rootSpan = \Keepsuit\LaravelOpenTelemetry\Facades\Tracer::newSpan('root')->start();
     $rootScope = $rootSpan->activate();
 
     $result = $callback();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -30,7 +30,7 @@ function getRecordedSpans(): array
 
 function withRootSpan(Closure $callback): mixed
 {
-    $rootSpan = \Keepsuit\LaravelOpenTelemetry\Facades\Tracer::build('root')->startSpan();
+    $rootSpan = \Keepsuit\LaravelOpenTelemetry\Facades\Tracer::newSpan('root')->startSpan();
     $rootScope = $rootSpan->activate();
 
     $result = $callback();

--- a/tests/Support/TestJob.php
+++ b/tests/Support/TestJob.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Spatie\Valuestore\Valuestore;
 
@@ -18,9 +19,10 @@ class TestJob implements ShouldQueue
     {
     }
 
-    public function handle()
+    public function handle(): void
     {
         $this->valuestore->put('traceparentInJob', $this->job->payload()['traceparent'] ?? null);
         $this->valuestore->put('traceIdInJob', Tracer::traceId());
+        $this->valuestore->put('logContextInJob', Log::sharedContext());
     }
 }

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -185,7 +185,7 @@ it('can record exceptions thrown in the callback', function () {
 
     expect($callbackSpan->toSpanData())
         ->hasEnded()->toBeTrue()
-        ->getStatus()->getCode()->toBe(StatusCode::STATUS_ERROR)
+        ->getStatus()->getCode()->toBe(StatusCode::STATUS_UNSET)
         ->getEvents()->toHaveCount(1);
 
     expect($callbackSpan->toSpanData()->getEvents()[0])
@@ -224,21 +224,6 @@ it('provides active span', function () {
     $scope = $span->activate();
 
     expect(Tracer::activeSpan())->toBe($span);
-
-    $scope->detach();
-    $span->end();
-});
-
-it('set traceId to log context', function () {
-    $span = Tracer::start('test span');
-    $scope = $span->activate();
-
-    Tracer::setRootSpan($span);
-
-    expect(Log::sharedContext())
-        ->toMatchArray([
-            'traceId' => $span->getContext()->getTraceId(),
-        ]);
 
     $scope->detach();
     $span->end();

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
@@ -224,6 +225,23 @@ it('provides active span', function () {
     $scope = $span->activate();
 
     expect(Tracer::activeSpan())->toBe($span);
+
+    $scope->detach();
+    $span->end();
+});
+
+it('set traceId to log context', function () {
+    $span = Tracer::start('test span');
+    $scope = $span->activate();
+
+    expect(Log::sharedContext())->toBe([]);
+
+    Tracer::updateLogContext();
+
+    expect(Log::sharedContext())
+        ->toMatchArray([
+            'traceId' => $span->getContext()->getTraceId(),
+        ]);
 
     $scope->detach();
     $span->end();

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Log;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -25,7 +25,7 @@ it('can resolve laravel tracer', function () {
 });
 
 it('can measure a span', function () {
-    $span = Tracer::start('test span');
+    $span = Tracer::newSpan('test span')->start();
 
     expect(Tracer::activeSpan())->not->toBe($span);
 
@@ -49,7 +49,7 @@ it('can measure a span', function () {
 it('can measure sequential spans', function () {
     $startTimestamp = ClockFactory::getDefault()->now();
 
-    $span1 = Tracer::start('test span 1');
+    $span1 = Tracer::newSpan('test span 1')->start();
     assert($span1 instanceof Span);
 
     expect(Tracer::activeSpan())->not->toBe($span1);
@@ -58,7 +58,7 @@ it('can measure sequential spans', function () {
 
     $span1->end();
 
-    $span2 = Tracer::start('test span 2');
+    $span2 = Tracer::newSpan('test span 2')->start();
     assert($span2 instanceof Span);
 
     expect(Tracer::activeSpan())->not->toBe($span2);
@@ -83,10 +83,10 @@ it('can measure sequential spans', function () {
 it('can measure parallel spans', function () {
     $startTimestamp = ClockFactory::getDefault()->now();
 
-    $span1 = Tracer::start('test span 1');
+    $span1 = Tracer::newSpan('test span 1')->start();
     assert($span1 instanceof Span);
 
-    $span2 = Tracer::start('test span 2');
+    $span2 = Tracer::newSpan('test span 2')->start();
     assert($span2 instanceof Span);
 
     expect(Tracer::activeSpan())
@@ -117,7 +117,7 @@ it('can measure parallel spans', function () {
 it('can measure nested spans', function () {
     $startTimestamp = ClockFactory::getDefault()->now();
 
-    $span1 = Tracer::start('test span 1');
+    $span1 = Tracer::newSpan('test span 1')->start();
     assert($span1 instanceof Span);
     $scope = $span1->activate();
 
@@ -125,7 +125,7 @@ it('can measure nested spans', function () {
 
     TestTime::addSecond();
 
-    $span2 = Tracer::start('test span 2');
+    $span2 = Tracer::newSpan('test span 2')->start();
     assert($span2 instanceof Span);
 
     expect(Tracer::activeSpan())->toBe($span1);
@@ -155,7 +155,7 @@ it('can measure nested spans', function () {
 
 it('can measure a callback', function () {
     /** @var Span $span */
-    $span = Tracer::measure('test span', function (SpanInterface $span) {
+    $span = Tracer::newSpan('test span')->measure(function (SpanInterface $span) {
         TestTime::addSecond();
 
         expect($span)
@@ -176,7 +176,7 @@ it('can record exceptions thrown in the callback', function () {
     $callbackSpan = null;
 
     try {
-        Tracer::measure('test span', function (SpanInterface $span) use (&$callbackSpan) {
+        Tracer::newSpan('test span')->measure(function (SpanInterface $span) use (&$callbackSpan) {
             $callbackSpan = $span;
 
             throw new Exception('test exception');
@@ -198,7 +198,7 @@ it('can record exceptions thrown in the callback', function () {
 });
 
 it('provides headers for propagation', function () {
-    $span = Tracer::start('test span');
+    $span = Tracer::newSpan('test span')->start();
     $scope = $span->activate();
 
     expect(Tracer::propagationHeaders())
@@ -211,7 +211,7 @@ it('provides headers for propagation', function () {
 });
 
 it('provides traceId and spanId for propagation', function () {
-    $span = Tracer::start('test span');
+    $span = Tracer::newSpan('test span')->start();
     $scope = $span->activate();
 
     expect(Tracer::traceId())->toBe($span->getContext()->getTraceId());
@@ -221,7 +221,7 @@ it('provides traceId and spanId for propagation', function () {
 });
 
 it('provides active span', function () {
-    $span = Tracer::start('test span');
+    $span = Tracer::newSpan('test span')->start();
     $scope = $span->activate();
 
     expect(Tracer::activeSpan())->toBe($span);
@@ -231,7 +231,7 @@ it('provides active span', function () {
 });
 
 it('set traceId to log context', function () {
-    $span = Tracer::start('test span');
+    $span = Tracer::newSpan('test span')->start();
     $scope = $span->activate();
 
     expect(Log::sharedContext())->toBe([]);

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
+use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
@@ -153,7 +154,7 @@ it('can measure nested spans', function () {
 
 it('can measure a callback', function () {
     /** @var Span $span */
-    $span = Tracer::measure('test span', function (Span $span) {
+    $span = Tracer::measure('test span', function (SpanInterface $span) {
         TestTime::addSecond();
 
         expect($span)
@@ -174,7 +175,7 @@ it('can record exceptions thrown in the callback', function () {
     $callbackSpan = null;
 
     try {
-        Tracer::measure('test span', function (Span $span) use (&$callbackSpan) {
+        Tracer::measure('test span', function (SpanInterface $span) use (&$callbackSpan) {
             $callbackSpan = $span;
 
             throw new Exception('test exception');


### PR DESCRIPTION
- Added new `SpanBuilder` which allows to create and start a span with fluent syntax:
```php
Tracer::newSpan('name')->setSpanKind(SpanKind::KIND_SERVER)->start();
```

- Removed `Tracer::start`, `Tracer::measure`, moved to span builder:
```php
Tracer::newSpan('name')->start();
Tracer::newSpan('name')->measure(callback);
```

- Removed `Tracer::measureAsync` (it was like `measure` with span kind `PRODUCER`), replaced with:
```php
Tracer::newSpan('name')->setSpanKind(SpanKind::KIND_PRODUCER)->measure(callback);
```

- Removed `Tracer::recordExceptionToSpan`, use span methods directly:
```php
$span->recordException($exception)
 ->setStatus(StatusCode::STATUS_ERROR); // optional, recordExceptionToSpan was setting the status to error
```

- Removed `Tracer::setRootSpan($span)`, it was only used to share traceId with log context. This has been replaced with `Tracer::updateLogContext()`