### PR TITLE
Track http headers

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
         options: --entrypoint redis-server
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [ 8.1, 8.2, 8.3 ]
         laravel: [ ^9.0, ^10.0 ]

--- a/README.md
+++ b/README.md
@@ -70,10 +70,16 @@ return [
         Instrumentation\HttpServerInstrumentation::class => [
             'enabled' => env('OT_INSTRUMENTATION_HTTP_SERVER', true),
             'excluded_paths' => [],
+            'allowed_headers' => [],
+            'sensitive_headers' => [],
         ],
 
-        Instrumentation\HttpClientInstrumentation::class => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
-        
+        Instrumentation\HttpClientInstrumentation::class => [
+            'enabled' => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
+            'allowed_headers' => [],
+            'sensitive_headers' => [],
+        ],
+
         Instrumentation\QueryInstrumentation::class => env('OT_INSTRUMENTATION_QUERY', true),
 
         Instrumentation\RedisInstrumentation::class => env('OT_INSTRUMENTATION_REDIS', true),

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ You can disable it by setting `OT_INSTRUMENTATION_HTTP_SERVER` to `false` or rem
 Configuration options:
 
 - `excluded_paths`: list of paths to exclude from tracing
+- `allowed_headers`: list of headers to include in the trace
+- `sensitive_headers`: list of headers with sensitive data to hide in the trace
 
 ### Http client
 
@@ -136,6 +138,13 @@ To trace an outgoing http request call the `withTrace` method on the request bui
 ```php
 Http::withTrace()->get('https://example.com');
 ```
+
+You can disable it by setting `OT_INSTRUMENTATION_HTTP_CLIENT` to `false` or removing the `HttpClientInstrumentation::class` from the config file.
+
+Configuration options:
+
+- `allowed_headers`: list of headers to include in the trace
+- `sensitive_headers`: list of headers with sensitive data to hide in the trace
 
 ### Database
 

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -37,7 +37,11 @@ return [
             'sensitive_headers' => [],
         ],
 
-        Instrumentation\HttpClientInstrumentation::class => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
+        Instrumentation\HttpClientInstrumentation::class => [
+            'enabled' => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
+            'allowed_headers' => [],
+            'sensitive_headers' => [],
+        ],
 
         Instrumentation\QueryInstrumentation::class => env('OT_INSTRUMENTATION_QUERY', true),
 

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -33,6 +33,8 @@ return [
         Instrumentation\HttpServerInstrumentation::class => [
             'enabled' => env('OT_INSTRUMENTATION_HTTP_SERVER', true),
             'excluded_paths' => [],
+            'allowed_headers' => [],
+            'sensitive_headers' => [],
         ],
 
         Instrumentation\HttpClientInstrumentation::class => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,4 +36,7 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <php>
+        <env name="APP_KEY" value="base64:Otue13cqTvN3tEEu1F5C25ku031q5HktoEk2AnOZEgg="/>
+    </php>
 </phpunit>

--- a/src/Instrumentation/HandlesHttpHeaders.php
+++ b/src/Instrumentation/HandlesHttpHeaders.php
@@ -37,12 +37,22 @@ trait HandlesHttpHeaders
         return static::$allowedHeaders;
     }
 
+    public static function headerIsAllowed(string $header): bool
+    {
+        return in_array($header, static::getAllowedHeaders());
+    }
+
     /**
      * @return array<string>
      */
     public static function getSensitiveHeaders(): array
     {
         return static::$sensitiveHeaders;
+    }
+
+    public static function headerIsSensitive(string $header): bool
+    {
+        return in_array($header, static::getSensitiveHeaders());
     }
 
     /**

--- a/src/Instrumentation/HandlesHttpHeaders.php
+++ b/src/Instrumentation/HandlesHttpHeaders.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Instrumentation;
+
+use Illuminate\Support\Arr;
+
+/**
+ * @internal
+ */
+trait HandlesHttpHeaders
+{
+    /**
+     * @var array<string>
+     */
+    protected array $defaultSensitiveHeaders = [
+        'authorization',
+        'php-auth-pw',
+        'cookie',
+        'set-cookie',
+    ];
+
+    /**
+     * @var array<string>
+     */
+    protected static array $allowedHeaders = [];
+
+    /**
+     * @var array<string>
+     */
+    protected static array $sensitiveHeaders = [];
+
+    /**
+     * @return array<string>
+     */
+    public static function getAllowedHeaders(): array
+    {
+        return static::$allowedHeaders;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getSensitiveHeaders(): array
+    {
+        return static::$sensitiveHeaders;
+    }
+
+    /**
+     * @param  array<string>  $headers
+     * @return array<string>
+     */
+    protected function normalizeHeaders(array $headers): array
+    {
+        return Arr::map(
+            $headers,
+            fn (string $header) => strtolower(trim($header)),
+        );
+    }
+}

--- a/src/Instrumentation/HttpClientInstrumentation.php
+++ b/src/Instrumentation/HttpClientInstrumentation.php
@@ -3,12 +3,22 @@
 namespace Keepsuit\LaravelOpenTelemetry\Instrumentation;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
 use Keepsuit\LaravelOpenTelemetry\Support\HttpClient\GuzzleTraceMiddleware;
 
 class HttpClientInstrumentation implements Instrumentation
 {
+    use HandlesHttpHeaders;
+
     public function register(array $options): void
     {
+        static::$allowedHeaders = $this->normalizeHeaders(Arr::get($options, 'allowed_headers', []));
+
+        static::$sensitiveHeaders = array_merge(
+            $this->normalizeHeaders(Arr::get($options, 'sensitive_headers', [])),
+            $this->defaultSensitiveHeaders
+        );
+
         $this->registerWithTraceMacro();
     }
 

--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -8,11 +8,41 @@ use Keepsuit\LaravelOpenTelemetry\Support\HttpServer\TraceRequestMiddleware;
 
 class HttpServerInstrumentation implements Instrumentation
 {
+    protected const DEFAULT_SENSITIVE_HEADERS = [
+        'authorization',
+        'php-auth-pw',
+        'cookie',
+        'set-cookie',
+    ];
+
     protected static array $excludedPaths = [];
 
+    protected static array $allowedHeaders = [];
+
+    protected static array $sensitiveHeaders = [];
+
+    /**
+     * @return array<string>
+     */
     public static function getExcludedPaths(): array
     {
         return static::$excludedPaths;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getAllowedHeaders(): array
+    {
+        return static::$allowedHeaders;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getSensitiveHeaders(): array
+    {
+        return static::$sensitiveHeaders;
     }
 
     public function register(array $options): void
@@ -20,6 +50,18 @@ class HttpServerInstrumentation implements Instrumentation
         static::$excludedPaths = array_map(
             fn (string $path) => ltrim($path, '/'),
             Arr::get($options, 'excluded_paths', [])
+        );
+
+        static::$allowedHeaders = array_map(
+            fn (string $header) => strtolower(trim($header)),
+            Arr::get($options, 'allowed_headers', [])
+        );
+        static::$sensitiveHeaders = array_merge(
+            array_map(
+                fn (string $header) => strtolower(trim($header)),
+                Arr::get($options, 'sensitive_headers', [])
+            ),
+            self::DEFAULT_SENSITIVE_HEADERS
         );
 
         $this->injectMiddleware(app(Kernel::class));

--- a/src/Support/HttpClient/GuzzleTraceMiddleware.php
+++ b/src/Support/HttpClient/GuzzleTraceMiddleware.php
@@ -73,11 +73,11 @@ class GuzzleTraceMiddleware
         foreach ($http->getHeaders() as $key => $value) {
             $key = strtolower($key);
 
-            if (! in_array($key, HttpClientInstrumentation::getAllowedHeaders())) {
+            if (! HttpClientInstrumentation::headerIsAllowed($key)) {
                 continue;
             }
 
-            $value = in_array($key, HttpClientInstrumentation::getSensitiveHeaders()) ? ['*****'] : $value;
+            $value = HttpClientInstrumentation::headerIsSensitive($key) ? ['*****'] : $value;
 
             $span->setAttribute($prefix.$key, $value);
         }

--- a/src/Support/HttpServer/TraceRequestMiddleware.php
+++ b/src/Support/HttpServer/TraceRequestMiddleware.php
@@ -104,11 +104,11 @@ class TraceRequestMiddleware
         foreach ($http->headers->all() as $key => $value) {
             $key = strtolower($key);
 
-            if (! in_array($key, HttpServerInstrumentation::getAllowedHeaders())) {
+            if (! HttpServerInstrumentation::headerIsAllowed($key)) {
                 continue;
             }
 
-            $value = in_array($key, HttpServerInstrumentation::getSensitiveHeaders()) ? ['*****'] : $value;
+            $value = HttpServerInstrumentation::headerIsSensitive($key) ? ['*****'] : $value;
 
             $span->setAttribute($prefix.$key, $value);
         }

--- a/src/Support/HttpServer/TraceRequestMiddleware.php
+++ b/src/Support/HttpServer/TraceRequestMiddleware.php
@@ -102,6 +102,8 @@ class TraceRequestMiddleware
         };
 
         foreach ($http->headers->all() as $key => $value) {
+            $key = strtolower($key);
+
             if (! in_array($key, HttpServerInstrumentation::getAllowedHeaders())) {
                 continue;
             }


### PR DESCRIPTION
Fixes #11 

This PR adds support for tracking http headers and hide sensitive values of headers if required.

This features is supported in both server and client instrumentation