### PR TITLE
Follow OTEL env variables specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,53 +43,70 @@ return [
     /**
      * Service name
      */
-    'service_name' => \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app')),
+    'service_name' => env('OTEL_SERVICE_NAME', \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app'))),
 
     /**
-     * Enable tracing
-     * Valid values: 'true', 'false', 'parent'
+     * Traces sampler
      */
-    'enabled' => env('OT_ENABLED', true),
+    'sampler' => [
+        /**
+         * Wraps the sampler in a parent based sampler
+         */
+        'parent' => env('OTEL_TRACES_SAMPLER_PARENT', true),
+
+        /**
+         * Sampler type
+         * Supported values: "always_on", "always_off", "traceidratio"
+         */
+        'type' => env('OTEL_TRACES_SAMPLER_TYPE', 'always_on'),
+
+        'args' => [
+            /**
+             * Sampling ratio for traceidratio sampler
+             */
+            'ratio' => env('OTEL_TRACES_SAMPLER_TRACEIDRATIO_RATIO', 0.05),
+        ],
+    ],
 
     /**
-     * Exporter to use
-     * Supported: 'zipkin', 'http', 'grpc', 'console', 'null'
+     * Traces exporter
+     * Supported: "zipkin", "http", "grpc", "console", "null"
      */
-    'exporter' => env('OT_EXPORTER', 'http'),
+    'exporter' => env('OTEL_TRACES_EXPORTER', 'http'),
 
     /**
-     * Propagator to use
-     * Supported: 'b3', 'b3multi', 'tracecontext',
+     * Comma separated list of propagators to use.
+     * Supports any otel propagator, for example: "tracecontext", "baggage", "b3", "b3multi", "none"
      */
-    'propagator' => env('OT_PROPAGATOR', 'tracecontext'),
+    'propagators' => env('OTEL_PROPAGATORS', 'tracecontext'),
 
     /**
      * List of instrumentation used for application tracing
      */
     'instrumentation' => [
         Instrumentation\HttpServerInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_HTTP_SERVER', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_HTTP_SERVER', true),
             'excluded_paths' => [],
             'allowed_headers' => [],
             'sensitive_headers' => [],
         ],
 
         Instrumentation\HttpClientInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_HTTP_CLIENT', true),
             'allowed_headers' => [],
             'sensitive_headers' => [],
         ],
 
-        Instrumentation\QueryInstrumentation::class => env('OT_INSTRUMENTATION_QUERY', true),
+        Instrumentation\QueryInstrumentation::class => env('OTEL_INSTRUMENTATION_QUERY', true),
 
-        Instrumentation\RedisInstrumentation::class => env('OT_INSTRUMENTATION_REDIS', true),
+        Instrumentation\RedisInstrumentation::class => env('OTEL_INSTRUMENTATION_REDIS', true),
 
-        Instrumentation\QueueInstrumentation::class => env('OT_INSTRUMENTATION_QUEUE', true),
+        Instrumentation\QueueInstrumentation::class => env('OTEL_INSTRUMENTATION_QUEUE', true),
 
-        Instrumentation\CacheInstrumentation::class => env('OT_INSTRUMENTATION_CACHE', true),
+        Instrumentation\CacheInstrumentation::class => env('OTEL_INSTRUMENTATION_CACHE', true),
 
         Instrumentation\EventInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_EVENT', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_EVENT', true),
             'ignored' => [],
         ],
     ],
@@ -98,19 +115,21 @@ return [
      * Exporters config
      */
     'exporters' => [
+        'otlp' => [
+            'endpoint' => env('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', env('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318')),
+
+            // Supported: "grpc", "http/protobuf", "http/json"
+            'protocol' => env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', env('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/protobuf')),
+        ],
+
         'zipkin' => [
-            'endpoint' => env('OT_ZIPKIN_HTTP_ENDPOINT', 'http://localhost:9411'),
-        ],
-
-        'http' => [
-            'endpoint' => env('OT_OTLP_HTTP_ENDPOINT', 'http://localhost:4318'),
-        ],
-
-        'grpc' => [
-            'endpoint' => env('OT_OTLP_GRPC_ENDPOINT', 'http://localhost:4317'),
+            'endpoint' => env('OTEL_EXPORTER_ZIPKIN_ENDPOINT', 'http://localhost:9411'),
         ],
     ],
 
+    /**
+     * Logs context config
+     */
     'logs' => [
         /**
          * Inject active trace id in log context

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10.51",
         "phpstan/phpstan-deprecation-rules": "^1.1",
+        "spatie/invade": "^2.0",
         "spatie/test-time": "^1.3",
         "spatie/valuestore": "^1.3",
         "thecodingmachine/phpstan-safe-rule": "^1.2"

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -10,21 +10,21 @@ return [
 
     /**
      * Enable tracing
-     * Valid values: 'true', 'false', 'parent'
+     * Valid values: "true", "false", "parent"
      */
     'enabled' => env('OTEL_ENABLED', true),
 
     /**
      * Exporter to use
-     * Supported: 'zipkin', 'http', 'grpc', 'console', 'null'
+     * Supported: "zipkin", "http", "grpc", "console", "null"
      */
     'exporter' => env('OTEL_EXPORTER', 'http'),
 
     /**
-     * Propagator to use
-     * Supported: 'b3', 'b3multi', 'tracecontext',
+     * Comma separated list of propagators to use.
+     * Supports any otel propagator, for example: "tracecontext", "baggage", "b3", "b3multi", "none"
      */
-    'propagator' => env('OTEL_PROPAGATOR', 'tracecontext'),
+    'propagators' => env('OTEL_PROPAGATORS', 'tracecontext'),
 
     /**
      * List of instrumentation used for application tracing

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -6,53 +6,53 @@ return [
     /**
      * Service name
      */
-    'service_name' => \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app')),
+    'service_name' => env('OTEL_SERVICE_NAME', \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app'))),
 
     /**
      * Enable tracing
      * Valid values: 'true', 'false', 'parent'
      */
-    'enabled' => env('OT_ENABLED', true),
+    'enabled' => env('OTEL_ENABLED', true),
 
     /**
      * Exporter to use
      * Supported: 'zipkin', 'http', 'grpc', 'console', 'null'
      */
-    'exporter' => env('OT_EXPORTER', 'http'),
+    'exporter' => env('OTEL_EXPORTER', 'http'),
 
     /**
      * Propagator to use
      * Supported: 'b3', 'b3multi', 'tracecontext',
      */
-    'propagator' => env('OT_PROPAGATOR', 'tracecontext'),
+    'propagator' => env('OTEL_PROPAGATOR', 'tracecontext'),
 
     /**
      * List of instrumentation used for application tracing
      */
     'instrumentation' => [
         Instrumentation\HttpServerInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_HTTP_SERVER', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_HTTP_SERVER', true),
             'excluded_paths' => [],
             'allowed_headers' => [],
             'sensitive_headers' => [],
         ],
 
         Instrumentation\HttpClientInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_HTTP_CLIENT', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_HTTP_CLIENT', true),
             'allowed_headers' => [],
             'sensitive_headers' => [],
         ],
 
-        Instrumentation\QueryInstrumentation::class => env('OT_INSTRUMENTATION_QUERY', true),
+        Instrumentation\QueryInstrumentation::class => env('OTEL_INSTRUMENTATION_QUERY', true),
 
-        Instrumentation\RedisInstrumentation::class => env('OT_INSTRUMENTATION_REDIS', true),
+        Instrumentation\RedisInstrumentation::class => env('OTEL_INSTRUMENTATION_REDIS', true),
 
-        Instrumentation\QueueInstrumentation::class => env('OT_INSTRUMENTATION_QUEUE', true),
+        Instrumentation\QueueInstrumentation::class => env('OTEL_INSTRUMENTATION_QUEUE', true),
 
-        Instrumentation\CacheInstrumentation::class => env('OT_INSTRUMENTATION_CACHE', true),
+        Instrumentation\CacheInstrumentation::class => env('OTEL_INSTRUMENTATION_CACHE', true),
 
         Instrumentation\EventInstrumentation::class => [
-            'enabled' => env('OT_INSTRUMENTATION_EVENT', true),
+            'enabled' => env('OTEL_INSTRUMENTATION_EVENT', true),
             'ignored' => [],
         ],
     ],
@@ -62,15 +62,15 @@ return [
      */
     'exporters' => [
         'zipkin' => [
-            'endpoint' => env('OT_ZIPKIN_HTTP_ENDPOINT', 'http://localhost:9411'),
+            'endpoint' => env('OTEL_ZIPKIN_HTTP_ENDPOINT', 'http://localhost:9411'),
         ],
 
         'http' => [
-            'endpoint' => env('OT_OTLP_HTTP_ENDPOINT', 'http://localhost:4318'),
+            'endpoint' => env('OTEL_OTLP_HTTP_ENDPOINT', 'http://localhost:4318'),
         ],
 
         'grpc' => [
-            'endpoint' => env('OT_OTLP_GRPC_ENDPOINT', 'http://localhost:4317'),
+            'endpoint' => env('OTEL_OTLP_GRPC_ENDPOINT', 'http://localhost:4317'),
         ],
     ],
 

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -78,16 +78,15 @@ return [
      * Exporters config
      */
     'exporters' => [
+        'otlp' => [
+            'endpoint' => env('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', env('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318')),
+
+            // Supported: "grpc", "http/protobuf", "http/json"
+            'protocol' => env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', env('OTEL_EXPORTER_OTLP_PROTOCOL', 'http')),
+        ],
+
         'zipkin' => [
             'endpoint' => env('OTEL_ZIPKIN_HTTP_ENDPOINT', 'http://localhost:9411'),
-        ],
-
-        'http' => [
-            'endpoint' => env('OTEL_OTLP_HTTP_ENDPOINT', 'http://localhost:4318'),
-        ],
-
-        'grpc' => [
-            'endpoint' => env('OTEL_OTLP_GRPC_ENDPOINT', 'http://localhost:4317'),
         ],
     ],
 

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -82,7 +82,7 @@ return [
             'endpoint' => env('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', env('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318')),
 
             // Supported: "grpc", "http/protobuf", "http/json"
-            'protocol' => env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', env('OTEL_EXPORTER_OTLP_PROTOCOL', 'http')),
+            'protocol' => env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', env('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/protobuf')),
         ],
 
         'zipkin' => [

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -90,6 +90,9 @@ return [
         ],
     ],
 
+    /**
+     * Logs context config
+     */
     'logs' => [
         /**
          * Inject active trace id in log context

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -86,7 +86,7 @@ return [
         ],
 
         'zipkin' => [
-            'endpoint' => env('OTEL_ZIPKIN_HTTP_ENDPOINT', 'http://localhost:9411'),
+            'endpoint' => env('OTEL_EXPORTER_ZIPKIN_ENDPOINT', 'http://localhost:9411'),
         ],
     ],
 

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -9,10 +9,27 @@ return [
     'service_name' => env('OTEL_SERVICE_NAME', \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app'))),
 
     /**
-     * Enable tracing
-     * Valid values: "true", "false", "parent"
+     * Traces sampler
      */
-    'enabled' => env('OTEL_ENABLED', true),
+    'sampler' => [
+        /**
+         * Wraps the sampler in a parent based sampler
+         */
+        'parent' => env('OTEL_TRACES_SAMPLER_PARENT', true),
+
+        /**
+         * Sampler type
+         * Supported values: "always_on", "always_off", "traceidratio"
+         */
+        'type' => env('OTEL_TRACES_SAMPLER_TYPE', 'always_on'),
+
+        'args' => [
+            /**
+             * Sampling ratio for traceidratio sampler
+             */
+            'ratio' => env('OTEL_TRACES_SAMPLER_TRACEIDRATIO_RATIO', 0.05),
+        ],
+    ],
 
     /**
      * Exporter to use

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -32,10 +32,10 @@ return [
     ],
 
     /**
-     * Exporter to use
+     * Traces exporter
      * Supported: "zipkin", "http", "grpc", "console", "null"
      */
-    'exporter' => env('OTEL_EXPORTER', 'http'),
+    'exporter' => env('OTEL_TRACES_EXPORTER', 'http'),
 
     /**
      * Comma separated list of propagators to use.

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -10,7 +10,6 @@ use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\Context\ScopeInterface;
 
 /**
- * @method static bool isRecording()
  * @method static string traceId()
  * @method static SpanInterface activeSpan()
  * @method static ScopeInterface|null activeScope()

--- a/src/Support/PropagatorBuilder.php
+++ b/src/Support/PropagatorBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Support;
+
+use Illuminate\Support\Facades\Log;
+use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
+use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
+use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+use OpenTelemetry\SDK\Registry;
+
+final class PropagatorBuilder
+{
+    public static function new(): PropagatorBuilder
+    {
+        return new PropagatorBuilder();
+    }
+
+    public function build(string $propagators): TextMapPropagatorInterface
+    {
+        $propagators = trim($propagators);
+
+        if ($propagators === '') {
+            return NoopTextMapPropagator::getInstance();
+        }
+
+        $propagators = explode(',', $propagators);
+
+        if (count($propagators) === 1) {
+            return $this->buildPropagator($propagators[0]);
+        }
+
+        return new MultiTextMapPropagator(array_map(fn (string $name) => $this->buildPropagator($name), $propagators));
+    }
+
+    protected function buildPropagator(string $name): TextMapPropagatorInterface
+    {
+        try {
+            return Registry::textMapPropagator($name);
+        } catch (\RuntimeException $e) {
+            Log::warning($e->getMessage());
+        }
+
+        return NoopTextMapPropagator::getInstance();
+    }
+}

--- a/src/Support/SamplerBuilder.php
+++ b/src/Support/SamplerBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Support;
+
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
+use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
+use OpenTelemetry\SDK\Trace\SamplerInterface;
+
+final class SamplerBuilder
+{
+    public static function new(): SamplerBuilder
+    {
+        return new SamplerBuilder();
+    }
+
+    public function build(string $sampler, bool $parentBased = false, array $args = []): SamplerInterface
+    {
+        $instance = $this->buildSampler(strtolower(trim($sampler)), $args);
+
+        if ($parentBased) {
+            return new ParentBased($instance);
+        }
+
+        return $instance;
+    }
+
+    protected function buildSampler(string $name, array $args): SamplerInterface
+    {
+        return match ($name) {
+            'always_on' => new AlwaysOnSampler(),
+            'traceidratio' => new TraceIdRatioBasedSampler($args['ratio'] ?? 0.05),
+            default => new AlwaysOffSampler(),
+        };
+    }
+}

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -40,21 +40,6 @@ class Tracer
         return $this->activeSpan()->getContext()->getTraceId();
     }
 
-    public function isRecording(): bool
-    {
-        $enabled = config('opentelemetry.enabled', true);
-
-        if (is_bool($enabled)) {
-            return $enabled;
-        }
-
-        if ($enabled === 'parent') {
-            return Span::getCurrent()->getContext()->isSampled();
-        }
-
-        return false;
-    }
-
     /**
      * @phpstan-param non-empty-string $name
      */

--- a/tests/Sdk/TracerTest.php
+++ b/tests/Sdk/TracerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Composer\InstalledVersions;
+use Keepsuit\LaravelOpenTelemetry\Support\PropagatorBuilder;
 
 it('can build open telemetry tracer', function () {
     /** @var \OpenTelemetry\SDK\Trace\Tracer $tracer */
@@ -12,4 +13,26 @@ it('can build open telemetry tracer', function () {
     expect($tracer->getInstrumentationScope())
         ->getName()->toBe('laravel-opentelemetry')
         ->getVersion()->toBe(InstalledVersions::getPrettyVersion('keepsuit/laravel-opentelemetry'));
+});
+
+it('can register multiple propagators', function () {
+    $propagator = PropagatorBuilder::new()->build('tracecontext,baggage,b3');
+
+    expect($propagator)
+        ->toBeInstanceOf(\OpenTelemetry\Context\Propagation\MultiTextMapPropagator::class)
+        ->fields()->toBe(['traceparent', 'tracestate', 'baggage', 'b3']);
+
+    $propagators = invade($propagator)->propagators;
+
+    expect($propagators[0])->toBeInstanceOf(\OpenTelemetry\API\Trace\Propagation\TraceContextPropagator::class);
+    expect($propagators[1])->toBeInstanceOf(\OpenTelemetry\API\Baggage\Propagation\BaggagePropagator::class);
+    expect($propagators[2])->toBeInstanceOf(\OpenTelemetry\Extension\Propagator\B3\B3Propagator::class);
+});
+
+it('register noop propagator when empty or invalid', function () {
+    expect(PropagatorBuilder::new()->build(''))
+        ->toBeInstanceOf(\OpenTelemetry\Context\Propagation\NoopTextMapPropagator::class);
+
+    expect(PropagatorBuilder::new()->build('invalid'))
+        ->toBeInstanceOf(\OpenTelemetry\Context\Propagation\NoopTextMapPropagator::class);
 });

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -19,7 +19,6 @@ it('can resolve laravel tracer', function () {
 
     expect($tracer)
         ->toBeInstanceOf(\Keepsuit\LaravelOpenTelemetry\Tracer::class)
-        ->isRecording()->toBeTrue()
         ->traceId()->toBe('00000000000000000000000000000000')
         ->activeSpan()->toBeInstanceOf(\OpenTelemetry\API\Trace\NonRecordingSpan::class);
 });


### PR DESCRIPTION
- Changed env variables prefix from `OT_` to `OTEL_`
- Changed env variables from OTEL specification
- Removed `enabled` config option, now it respect otel sdk `isDisabled` option
- Refactoring sampler config and added `ratio` sampler
- Added support for multiple propagators
- Unified `otlp` exporters (http/grpc) with a protocol setting