### PR TITLE
Skip recording of internal spans when trace is not started

### DIFF
--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -10,6 +10,7 @@ use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\Context\ScopeInterface;
 
 /**
+ * @method static bool traceStarted()
  * @method static string|null traceId()
  * @method static SpanInterface activeSpan()
  * @method static ScopeInterface|null activeScope()

--- a/src/Instrumentation/QueryInstrumentation.php
+++ b/src/Instrumentation/QueryInstrumentation.php
@@ -20,6 +20,10 @@ class QueryInstrumentation implements Instrumentation
 
     public function recordQuery(QueryExecuted $event): void
     {
+        if (! Tracer::traceStarted()) {
+            return;
+        }
+
         $operationName = Str::of($event->sql)
             ->before(' ')
             ->upper()

--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -58,6 +58,10 @@ class QueueInstrumentation implements Instrumentation
     {
         try {
             $queue->createPayloadUsing(function (string $connection, ?string $queue, array $payload) {
+                if (! Tracer::traceStarted()) {
+                    return $payload;
+                }
+
                 $uuid = $payload['uuid'];
 
                 if (! is_string($uuid)) {

--- a/src/Instrumentation/RedisInstrumentation.php
+++ b/src/Instrumentation/RedisInstrumentation.php
@@ -25,6 +25,10 @@ class RedisInstrumentation implements Instrumentation
 
     public function recordCommand(CommandExecuted $event): void
     {
+        if (! Tracer::traceStarted()) {
+            return;
+        }
+
         $traceName = sprintf('redis %s %s', $event->connection->getName(), $event->command);
 
         $span = Tracer::newSpan($traceName)

--- a/src/Support/HttpClient/GuzzleTraceMiddleware.php
+++ b/src/Support/HttpClient/GuzzleTraceMiddleware.php
@@ -19,6 +19,10 @@ class GuzzleTraceMiddleware
     {
         return static function (callable $handler): callable {
             return static function (RequestInterface $request, array $options) use ($handler) {
+                if (! Tracer::traceStarted()) {
+                    return $handler($request, $options);
+                }
+
                 $span = Tracer::newSpan(sprintf('HTTP %s', $request->getMethod()))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::URL_FULL, sprintf('%s://%s%s', $request->getUri()->getScheme(), $request->getUri()->getHost(), $request->getUri()->getPath()))

--- a/src/Support/SpanBuilder.php
+++ b/src/Support/SpanBuilder.php
@@ -105,8 +105,8 @@ class SpanBuilder
 
             throw $exception;
         } finally {
-            $span->end();
             $scope->detach();
+            $span->end();
         }
     }
 }

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -20,6 +20,11 @@ class Tracer
         protected TextMapPropagatorInterface $propagator
     ) {}
 
+    public function traceStarted(): bool
+    {
+        return $this->activeSpan()->getContext()->isValid();
+    }
+
     public function currentContext(): ContextInterface
     {
         return Context::getCurrent();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Collection;
+use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
@@ -44,15 +45,7 @@ function getRecordedSpans(): Collection
 
 function withRootSpan(Closure $callback): mixed
 {
-    $rootSpan = \Keepsuit\LaravelOpenTelemetry\Facades\Tracer::newSpan('root')->start();
-    $rootScope = $rootSpan->activate();
-
-    $result = $callback();
-
-    $rootScope->detach();
-    $rootSpan->end();
-
-    return $result;
+    return Tracer::newSpan('root')->measure($callback);
 }
 
 /**

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -245,3 +245,19 @@ it('set traceId to log context', function () {
     $scope->detach();
     $span->end();
 });
+
+test('trace started', function () {
+    expect(Tracer::traceStarted())->toBeFalse();
+
+    // Root span (not active)
+    $rootSpan = Tracer::newSpan('root')->start();
+    expect(Tracer::traceStarted())->toBeFalse();
+
+    // Root span (active)
+    $scope = $rootSpan->activate();
+    expect(Tracer::traceStarted())->toBeTrue();
+
+    $scope->detach();
+    $rootSpan->end();
+    expect(Tracer::traceStarted())->toBeFalse();
+});


### PR DESCRIPTION
- Added `traceStarted` helper to `Tracer` that returns `true` when a root span exist and is active.
- Skip `recording` of internal spans when trace is not started:
  - query
  - redis
  - http client
  - queue (only enqueue), the queue worker can create a root span depending on sampler

