### PR TITLE
feat: add Meter/Metrics support, and enable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ use Keepsuit\LaravelOpenTelemetry\Instrumentation;
 
 return [
     /**
+     * Enable OpenTelemetry
+     */
+    'enabled' => env('OTEL_ENABLED', true),
+
+    /**
      * Service name
      */
     'service_name' => env('OTEL_SERVICE_NAME', \Illuminate\Support\Str::slug(env('APP_NAME', 'laravel-app'))),
@@ -41,6 +46,18 @@ return [
      * Supports any otel propagator, for example: "tracecontext", "baggage", "b3", "b3multi", "none"
      */
     'propagators' => env('OTEL_PROPAGATORS', 'tracecontext'),
+
+    /**
+     * OpenTelemetry Meter configuration
+     */
+    'metrics' => [
+        /**
+         * Metrics exporter
+         * This should be the key of one of the exporters defined in the exporters section
+         * Supported drivers: "otlp", "console", "null"
+         */
+        'exporter' => env('OTEL_METRICS_EXPORTER', 'otlp'),
+    ],
 
     /**
      * OpenTelemetry Traces configuration
@@ -104,7 +121,7 @@ return [
     /**
      * OpenTelemetry exporters
      *
-     * Here you can configure exports used by traces and logs.
+     * Here you can configure exports used by metrics, traces and logs.
      * If you want to use the same protocol with different endpoints,
      * you can copy the exporter with a different and change the endpoint
      *
@@ -186,6 +203,7 @@ You can disable or customize each integration in the config file in the `instrum
 - [Redis](#redis)
 - [Queue jobs](#redis)
 - [Logs context](#logs-context)
+- [Custom meters](#custom-meters)
 - [Manual traces](#manual-traces)
 
 ### Http server requests
@@ -241,6 +259,29 @@ you should call `Tracer::updateLogContext()` to inject the trace id in the log c
 > [!NOTE]
 > When using the OpenTelemetry logs driver (`otlp`),
 > the trace id is automatically injected in the log context without the need to call `Tracer::updateLogContext()`.
+
+### Custom Meters
+
+You can create custom meters using the `Meter` facade:
+
+```php
+use Keepsuit\LaravelOpenTelemetry\Facades\Meter;
+
+// create a counter meter
+$meter = Meter::createCounter('my-meter', 'times', 'my custom meter');
+$meter->add(1);
+
+
+// create a histogram meter
+$meter = Meter::createHistogram('my-histogram', 'ms', 'my custom histogram');
+$meter->record(100, ['name' => 'value', 'app' => 'my-app']);
+
+
+// create a gauge meter
+$meter = Meter::createGauge('my-gauge', null, 'my custom gauge');
+$meter->record(100, ['name' => 'value', 'app' => 'my-app']);
+$meter->record(1.2, ['name' => 'percentage', 'app' => 'my-app']);
+```
 
 ### Manual traces
 
@@ -342,6 +383,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Credits
 
 - [Fabio Capucci](https://github.com/keepsuit)
+- [Aurimas Niekis](https://github.com/aurimasniekis)
 - [All Contributors](../../contributors)
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "spatie/laravel-ray": "^1.40",
         "spatie/test-time": "^1.3",
         "spatie/valuestore": "^1.3",
-        "thecodingmachine/phpstan-safe-rule": "^1.2"
+        "thecodingmachine/phpstan-safe-rule": "^1.4"
     },
     "suggest": {
         "open-telemetry/extension-propagator-b3": "Required to use B3 propagator",

--- a/config/opentelemetry.php
+++ b/config/opentelemetry.php
@@ -5,6 +5,11 @@ use OpenTelemetry\SDK\Common\Configuration\Variables;
 
 return [
     /**
+     * Enable OpenTelemetry
+     */
+    'enabled' => env('OTEL_ENABLED', true),
+
+    /**
      * Service name
      */
     'service_name' => env(Variables::OTEL_SERVICE_NAME, \Illuminate\Support\Str::slug((string) env('APP_NAME', 'laravel-app'))),
@@ -14,6 +19,18 @@ return [
      * Supports any otel propagator, for example: "tracecontext", "baggage", "b3", "b3multi", "none"
      */
     'propagators' => env(Variables::OTEL_PROPAGATORS, 'tracecontext'),
+
+    /**
+     * OpenTelemetry Meter configuration
+     */
+    'metrics' => [
+        /**
+         * Metrics exporter
+         * This should be the key of one of the exporters defined in the exporters section
+         * Supported drivers: "otlp", "console", "null"
+         */
+        'exporter' => env('OTEL_INSTRUMENTATIONS_EXPORTER', 'otlp'),
+    ],
 
     /**
      * OpenTelemetry Traces configuration
@@ -77,7 +94,7 @@ return [
     /**
      * OpenTelemetry exporters
      *
-     * Here you can configure exports used by traces and logs.
+     * Here you can configure exports used by metrics, traces and logs.
      * If you want to use the same protocol with different endpoints,
      * you can copy the exporter with a different and change the endpoint
      *

--- a/src/Facades/Meter.php
+++ b/src/Facades/Meter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use OpenTelemetry\API\Metrics\AsynchronousInstrument;
+use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
+use OpenTelemetry\API\Metrics\ObservableCounterInterface;
+use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
+use OpenTelemetry\API\Metrics\ObservableUpDownCounterInterface;
+use OpenTelemetry\API\Metrics\UpDownCounterInterface;
+
+/**
+ * @method static ObservableCallbackInterface batchObserve(callable $callback, AsynchronousInstrument $instrument, AsynchronousInstrument ...$instruments)
+ * @method static CounterInterface createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = [])
+ * @method static ObservableCounterInterface createObservableCounter(string $name, ?string $unit = null, ?string $description = null, array|callable $advisory = [], callable ...$callbacks)
+ * @method static HistogramInterface createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = [])
+ * @method static GaugeInterface createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = [])
+ * @method static ObservableGaugeInterface createObservableGauge(string $name, ?string $unit = null, ?string $description = null, array|callable $advisory = [], callable ...$callbacks)
+ * @method static UpDownCounterInterface createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = [])
+ * @method static ObservableUpDownCounterInterface createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array|callable $advisory = [], callable ...$callbacks)
+ * @method static bool collect()
+ *
+ * @see \Keepsuit\LaravelOpenTelemetry\Meter
+ */
+class Meter extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return \Keepsuit\LaravelOpenTelemetry\Meter::class;
+    }
+}

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -17,12 +17,14 @@ use Keepsuit\LaravelOpenTelemetry\Support\SamplerBuilder;
 use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Logs\LoggerInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Signals;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\Contrib\Grpc\GrpcTransportFactory;
 use OpenTelemetry\Contrib\Otlp\HttpEndpointResolver;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
+use OpenTelemetry\Contrib\Otlp\MetricExporter;
 use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
 use OpenTelemetry\Contrib\Otlp\SpanExporter as OtlpSpanExporter;
@@ -37,6 +39,12 @@ use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporterFactory as LogsInMemoryExpor
 use OpenTelemetry\SDK\Logs\LoggerProvider;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 use OpenTelemetry\SDK\Logs\Processor\BatchLogRecordProcessor;
+use OpenTelemetry\SDK\Metrics\MeterProvider;
+use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricExporterFactory;
+use OpenTelemetry\SDK\Metrics\MetricExporter\InMemoryExporterFactory;
+use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
+use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
+use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Sdk;
@@ -54,6 +62,10 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
 {
     public function packageBooted(): void
     {
+        if (!config('opentelemetry.enabled')) {
+            return;
+        }
+
         $this->configureEnvironmentVariables();
         $this->injectConfig();
         $this->init();
@@ -78,6 +90,17 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         );
 
         $propagator = PropagatorBuilder::new()->build(config('opentelemetry.propagators'));
+
+        /**
+         * Metrics
+         */
+        $metricsExporter = $this->buildMetricsExporter();
+        $metricsReader = new ExportingReader($metricsExporter);
+
+        $meterProvider = MeterProvider::builder()
+            ->setResource($resource)
+            ->addReader($metricsReader)
+            ->build();
 
         /**
          * Traces
@@ -117,6 +140,7 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         Sdk::builder()
             ->setTracerProvider($tracerProvider)
             ->setLoggerProvider($loggerProvider)
+            ->setMeterProvider($meterProvider)
             ->setPropagator($propagator)
             ->setAutoShutdown(true)
             ->buildAndRegisterGlobal();
@@ -128,12 +152,15 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         );
 
         $this->app->bind(TextMapPropagatorInterface::class, fn () => $propagator);
+        $this->app->bind(MeterInterface::class, fn () => $instrumentation->meter());
         $this->app->bind(TracerInterface::class, fn () => $instrumentation->tracer());
         $this->app->bind(LoggerInterface::class, fn () => $instrumentation->logger());
+        $this->app->bind(MetricReaderInterface::class, fn () => $metricsReader);
 
-        $this->app->terminating(function () use ($loggerProvider, $tracerProvider) {
+        $this->app->terminating(function () use ($loggerProvider, $tracerProvider, $meterProvider) {
             $tracerProvider->forceFlush();
             $loggerProvider->forceFlush();
+            $meterProvider->forceFlush();
         });
     }
 
@@ -156,6 +183,19 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
 
         // Disable debug scopes wrapping
         $envRepository->set('OTEL_PHP_DEBUG_SCOPES_DISABLED', '1');
+    }
+
+    protected function buildMetricsExporter(): MetricExporterInterface
+    {
+        $metricsExporter = config('opentelemetry.metrics.exporter');
+        $metricsExporterConfig = config(sprintf('opentelemetry.exporters.%s', $metricsExporter));
+        $metricsExporterDriver = is_array($metricsExporterConfig) ? $metricsExporterConfig['driver'] : $metricsExporter;
+
+        return match ($metricsExporterDriver) {
+            'otlp' => new MetricExporter($this->buildOtlpTransport($metricsExporterConfig ?? [], Signals::METRICS)),
+            'console' => (new ConsoleMetricExporterFactory())->create(),
+            default => (new InMemoryExporterFactory())->create(),
+        };
     }
 
     protected function buildSpanExporter(): SpanExporterInterface

--- a/src/Meter.php
+++ b/src/Meter.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry;
+
+use OpenTelemetry\API\Metrics\AsynchronousInstrument;
+use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
+use OpenTelemetry\API\Metrics\ObservableCounterInterface;
+use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
+use OpenTelemetry\API\Metrics\ObservableUpDownCounterInterface;
+use OpenTelemetry\API\Metrics\UpDownCounterInterface;
+use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
+
+class Meter
+{
+    public function __construct(
+        protected MeterInterface $meter,
+        protected MetricReaderInterface $reader
+    )
+    {
+    }
+
+    /**
+     * Creates a `Counter`.
+     *
+     * @param string $name name of the instrument
+     * @param ?string $unit unit of measure
+     * @param ?string $description description of the instrument
+     * @param array $advisory an optional set of recommendations
+     * @return CounterInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#counter-creation
+     */
+    public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): CounterInterface
+    {
+        return $this->meter->createCounter($name, $unit, $description, $advisory);
+    }
+
+    /**
+     * Creates an `ObservableCounter`.
+     *
+     * @param string $name name of the instrument
+     * @param ?string $unit unit of measure
+     * @param ?string $description description of the instrument
+     * @param array|callable $advisory an optional set of recommendations, or
+     *        deprecated: the first callback to report measurements
+     * @param callable ...$callbacks responsible for reporting measurements
+     * @return ObservableCounterInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation
+     */
+    public function createObservableCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableCounterInterface
+    {
+        return $this->meter->createObservableCounter($name, $unit, $description, $advisory, ...$callbacks);
+    }
+
+
+    /**
+     * Reports measurements for multiple asynchronous instrument from a single callback.
+     *
+     * The callback receives an {@link ObserverInterface} for each instrument. All provided
+     * instruments have to be created by this meter.
+     *
+     * ```php
+     * $callback = $meter->batchObserve(
+     *     function(
+     *         ObserverInterface $usageObserver,
+     *         ObserverInterface $pressureObserver,
+     *     ): void {
+     *         [$usage, $pressure] = expensive_system_call();
+     *         $usageObserver->observe($usage);
+     *         $pressureObserver->observe($pressure);
+     *     },
+     *     $meter->createObservableCounter('usage', description: 'count of items used'),
+     *     $meter->createObservableGauge('pressure', description: 'force per unit area'),
+     * );
+     * ```
+     *
+     * @param callable $callback function responsible for reporting the measurements
+     * @param AsynchronousInstrument $instrument first instrument to report measurements for
+     * @param AsynchronousInstrument ...$instruments additional instruments to report measurements for
+     * @return ObservableCallbackInterface token to detach callback
+     *
+     * @see https://opentelemetry.io/docs/specs/otel/metrics/api/#multiple-instrument-callbacks
+     */
+    public function batchObserve(callable $callback, AsynchronousInstrument $instrument, AsynchronousInstrument ...$instruments): ObservableCallbackInterface
+    {
+        return $this->meter->batchObserve($callback, $instrument, ...$instruments);
+    }
+
+    /**
+     * Creates a `Histogram`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array $advisory an optional set of recommendations, e.g.
+     *        <code>['ExplicitBucketBoundaries' => [0.25, 0.5, 1, 5]]</code>
+     * @return HistogramInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#histogram-creation
+     */
+    public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
+    {
+        return $this->meter->createHistogram($name, $unit, $description, $advisory);
+    }
+
+    /**
+     * Creates a `Gauge`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array $advisory an optional set of recommendations
+     * @return GaugeInterface created instrument
+     *
+     * @see https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge-creation
+     *
+     * @experimental
+     */
+    public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
+    {
+        return $this->meter->createGauge($name, $unit, $description, $advisory);
+    }
+
+    /**
+     * Creates an `ObservableGauge`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array|callable $advisory an optional set of recommendations, or
+     *        deprecated: the first callback to report measurements
+     * @param callable ...$callbacks responsible for reporting measurements
+     * @return ObservableGaugeInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-gauge-creation
+     */
+    public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableGaugeInterface
+    {
+        return $this->meter->createObservableGauge($name, $unit, $description, $advisory, ...$callbacks);
+    }
+
+    /**
+     * Creates an `UpDownCounter`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array $advisory an optional set of recommendations
+     * @return UpDownCounterInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#updowncounter-creation
+     */
+    public function createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): UpDownCounterInterface
+    {
+        return $this->meter->createUpDownCounter($name, $unit, $description, $advisory);
+    }
+
+    /**
+     * Creates an `ObservableUpDownCounter`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array|callable $advisory an optional set of recommendations, or
+     *        deprecated: the first callback to report measurements
+     * @param callable ...$callbacks responsible for reporting measurements
+     * @return ObservableUpDownCounterInterface created instrument
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-updowncounter-creation
+     */
+    public function createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableUpDownCounterInterface
+    {
+        return $this->meter->createObservableUpDownCounter($name, $unit, $description, $advisory, ...$callbacks);
+    }
+
+    public function collect(): bool
+    {
+        return $this->reader->collect();
+    }
+}


### PR DESCRIPTION
- Implemented OpenTelemetry Meter/Metrics support, which was previously missing.
- Introduced an `enabled` flag to allow disabling OpenTelemetry in development environments.
- Ensured compatibility with existing tracing and context propagation.

This improves observability by extending OpenTelemetry beyond tracing to include metrics, while also providing flexibility to disable telemetry in non-production environments.