### PR TITLE
fix: enhance exception tracing in http server instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM serversideup/php:8.2-cli
+
+ARG USER_ID
+ARG GROUP_ID
+
+USER root
+
+RUN install-php-extensions grpc
+RUN docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID
+
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM serversideup/php:8.2-cli
 
-ARG USER_ID
-ARG GROUP_ID
+# see: https://serversideup.net/open-source/docker-php/docs/guide/understanding-file-permissions#how-it-works
+ARG USER_ID=33
+ARG GROUP_ID=33
+
+# see: https://serversideup.net/open-source/docker-php/docs/reference/environment-variable-specification
+ENV SHOW_WELCOME_MESSAGE=false
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -335,11 +335,15 @@ To simplify development, a `Makefile` is provided. The project runs in a Docker 
 
 #### Available Makefile Commands
 
-| Command       | Description                                                      |
-|---------------|------------------------------------------------------------------|
-| `make build`  | Builds the Docker image with your UID/GID for permission safety. |
-| `make start`  | Starts the container interactively and mounts the project code.  |
-| `make shell`  | Opens a Bash shell **inside the running container**.             |
+| Command        | Description                                                                 |
+|----------------|-----------------------------------------------------------------------------|
+| `make build`   | Builds the Docker image with your UID/GID for proper file permissions.     |
+| `make start`   | Starts the containers in the background using Docker Compose.              |
+| `make stop`    | Stops and removes the containers.                                           |
+| `make shell`   | Starts the containers (if needed) and opens a Bash shell in the `app` one. |
+| `make test`    | Runs the test suite via Composer inside the `app` container.               |
+| `make lint`    | Runs the linter via Composer inside the `app` container.                   |
+
 
 > 📝 Before using `make shell`, ensure the container is running (`make start` in another terminal).
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ Logger::info('my log message');
 Logger::debug('my log message');
 ```
 
+### Development Setup
+
+To simplify development, a `Makefile` is provided. The project runs in a Docker container that mirrors your host user's UID and GID to avoid permission issues.
+
+#### Available Makefile Commands
+
+| Command       | Description                                                      |
+|---------------|------------------------------------------------------------------|
+| `make build`  | Builds the Docker image with your UID/GID for permission safety. |
+| `make start`  | Starts the container interactively and mounts the project code.  |
+| `make shell`  | Opens a Bash shell **inside the running container**.             |
+
+> 📝 Before using `make shell`, ensure the container is running (`make start` in another terminal).
+
 ## Testing
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  app:
+    image: laravel-opentelemetry-development
+    tty: true
+    stdin_open: true
+    environment:
+      REDIS_HOST: 'redis'
+    build:
+      context: .
+      args:
+        USER_ID: "${USER_ID:-1000}"
+        GROUP_ID: "${GROUP_ID:-1000}"
+    volumes:
+      - .:/var/www/html
+    depends_on:
+      - redis
+    networks:
+      - dev
+
+  redis:
+    image: 'redis:alpine'
+    networks:
+      - dev
+
+networks:
+  dev:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
     image: laravel-opentelemetry-development
     tty: true
     stdin_open: true
+    entrypoint: /bin/bash
     environment:
       REDIS_HOST: 'redis'
     build:
       context: .
       args:
-        USER_ID: "${USER_ID:-1000}"
-        GROUP_ID: "${GROUP_ID:-1000}"
+        USER_ID: "${USER_ID:-33}"
+        GROUP_ID: "${GROUP_ID:-33}"
     volumes:
       - .:/var/www/html
     depends_on:

--- a/makefile
+++ b/makefile
@@ -1,11 +1,14 @@
-USER_ID = $(shell id -u)
-GROUP_ID = $(shell id -g)
+.PHONY: $(MAKECMDGOALS)
 
 build:
-	USER_ID=$(USER_ID) GROUP_ID=$(GROUP_ID) docker compose build
+	docker compose build \
+		--build-arg USER_ID=$(shell id -u) \
+		--build-arg GROUP_ID=$(shell id -g)
 
 start:
-	docker compose up -d
+	@if ! docker compose ps --format '{{.Service}} {{.State}}' | grep -q '^app running$$'; then \
+		docker compose up -d; \
+	fi
 
 stop:
 	docker compose down

--- a/makefile
+++ b/makefile
@@ -1,12 +1,23 @@
-IMAGE_NAME = laravel-opentelemetry-development
-CONTAINER_NAME = $(IMAGE_NAME)
+USER_ID = $(shell id -u)
+GROUP_ID = $(shell id -g)
 
 build:
-	docker build -t $(IMAGE_NAME) --build-arg USER_ID=$(shell id -u) --build-arg GROUP_ID=$(shell id -g) .
+	USER_ID=$(USER_ID) GROUP_ID=$(GROUP_ID) docker compose build
 
 start:
-	docker run --rm -it --name $(CONTAINER_NAME) -v $(CURDIR):/var/www/html $(IMAGE_NAME)
+	docker compose up -d
+
+stop:
+	docker compose down
 
 shell:
-	docker exec -it $(CONTAINER_NAME) /bin/bash || \
-	echo "Container '$(CONTAINER_NAME)' is not running. Start it with 'make start', or build it with 'make build' if you didn't yet."
+	make start
+	docker compose exec -it app /bin/bash
+
+test:
+	make start
+	docker compose exec -it app /usr/bin/composer test
+
+lint:
+	make start
+	docker compose exec -it app /usr/bin/composer lint

--- a/makefile
+++ b/makefile
@@ -1,0 +1,12 @@
+IMAGE_NAME = laravel-opentelemetry-development
+CONTAINER_NAME = $(IMAGE_NAME)
+
+build:
+	docker build -t $(IMAGE_NAME) --build-arg USER_ID=$(shell id -u) --build-arg GROUP_ID=$(shell id -g) .
+
+start:
+	docker run --rm -it --name $(CONTAINER_NAME) -v $(CURDIR):/var/www/html $(IMAGE_NAME)
+
+shell:
+	docker exec -it $(CONTAINER_NAME) /bin/bash || \
+	echo "Container '$(CONTAINER_NAME)' is not running. Start it with 'make start', or build it with 'make build' if you didn't yet."

--- a/src/Facades/Tracer.php
+++ b/src/Facades/Tracer.php
@@ -19,6 +19,7 @@ use OpenTelemetry\Context\ScopeInterface;
  * @method static Context|null extractContextFromPropagationHeaders(array $headers)
  * @method static SpanBuilder newSpan(string $name)
  * @method static void updateLogContext()
+ * @method static void terminateActiveSpansUpToRoot(?SpanInterface $root = null)
  */
 class Tracer extends Facade
 {

--- a/src/Instrumentation/ConsoleInstrumentation.php
+++ b/src/Instrumentation/ConsoleInstrumentation.php
@@ -71,6 +71,8 @@ class ConsoleInstrumentation implements Instrumentation
          */
         [$span, $scope] = $trace;
 
+        Tracer::terminateActiveSpansUpToRoot($span);
+
         if ($event->exitCode !== 0) {
             $span->setStatus(StatusCode::STATUS_ERROR);
         } else {

--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -60,8 +60,7 @@ class HttpServerInstrumentation implements Instrumentation
         if ($handler instanceof FoundationExceptionHandler) {
             $handler->reportable(fn (Throwable $e) => Tracer::activeSpan()
                 ->recordException($e)
-                ->setStatus(StatusCode::STATUS_ERROR)
-                ->end(),
+                ->setStatus(StatusCode::STATUS_ERROR),
             );
         }
     }

--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -2,15 +2,10 @@
 
 namespace Keepsuit\LaravelOpenTelemetry\Instrumentation;
 
-use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
-use Illuminate\Foundation\Exceptions\Handler as FoundationExceptionHandler;
 use Illuminate\Foundation\Http\Kernel as FoundationHttpKernel;
 use Illuminate\Support\Arr;
-use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Support\HttpServer\TraceRequestMiddleware;
-use OpenTelemetry\API\Trace\StatusCode;
-use Throwable;
 
 class HttpServerInstrumentation implements Instrumentation
 {
@@ -40,7 +35,6 @@ class HttpServerInstrumentation implements Instrumentation
             $this->defaultSensitiveHeaders,
         );
 
-        $this->recordExceptionInSpan(app(ExceptionHandlerContract::class));
         $this->injectMiddleware(app(HttpKernelContract::class));
     }
 
@@ -52,16 +46,6 @@ class HttpServerInstrumentation implements Instrumentation
 
         if (! $kernel->hasMiddleware(TraceRequestMiddleware::class)) {
             $kernel->prependMiddleware(TraceRequestMiddleware::class);
-        }
-    }
-
-    protected function recordExceptionInSpan(ExceptionHandlerContract $handler): void
-    {
-        if ($handler instanceof FoundationExceptionHandler) {
-            $handler->reportable(fn (Throwable $e) => Tracer::activeSpan()
-                ->recordException($e)
-                ->setStatus(StatusCode::STATUS_ERROR),
-            );
         }
     }
 }

--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -55,7 +55,6 @@ class HttpServerInstrumentation implements Instrumentation
         }
     }
 
-
     protected function recordExceptionInSpan(ExceptionHandlerContract $handler): void
     {
         if ($handler instanceof FoundationExceptionHandler) {

--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -60,7 +60,8 @@ class HttpServerInstrumentation implements Instrumentation
         if ($handler instanceof FoundationExceptionHandler) {
             $handler->reportable(fn (Throwable $e) => Tracer::activeSpan()
                 ->recordException($e)
-                ->setStatus(StatusCode::STATUS_ERROR),
+                ->setStatus(StatusCode::STATUS_ERROR)
+                ->end(),
             );
         }
     }

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -157,6 +157,10 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         });
 
         $this->callAfterResolving(ExceptionHandlerContract::class, function (ExceptionHandlerContract $handler) {
+            if (! method_exists($handler, 'reportable')) {
+                return;
+            }
+
             $handler->reportable(function (Throwable $e) {
                 Tracer::activeSpan()
                     ->recordException($e)

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -157,6 +157,7 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
         });
 
         $this->callAfterResolving(ExceptionHandlerContract::class, function (ExceptionHandlerContract $handler) {
+            /** @phpstan-ignore-next-line */
             if (! method_exists($handler, 'reportable')) {
                 return;
             }

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -6,11 +6,13 @@ use Composer\InstalledVersions;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
+use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Support\CarbonClock;
 use Keepsuit\LaravelOpenTelemetry\Support\OpenTelemetryMonologHandler;
 use Keepsuit\LaravelOpenTelemetry\Support\PropagatorBuilder;
@@ -19,6 +21,7 @@ use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Logs\LoggerInterface;
 use OpenTelemetry\API\Signals;
+use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\Contrib\Grpc\GrpcTransportFactory;
@@ -50,6 +53,7 @@ use OpenTelemetry\SemConv\ResourceAttributes;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Throwable;
 
 class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
 {
@@ -150,6 +154,14 @@ class LaravelOpenTelemetryServiceProvider extends PackageServiceProvider
 
         $this->app->booted(function (Application $app) {
             $app->register(InstrumentationServiceProvider::class);
+        });
+
+        $this->callAfterResolving(ExceptionHandlerContract::class, function (ExceptionHandlerContract $handler) {
+            $handler->reportable(function (Throwable $e) {
+                Tracer::activeSpan()
+                    ->recordException($e)
+                    ->setStatus(StatusCode::STATUS_ERROR);
+            });
         });
     }
 

--- a/src/Support/HttpServer/TraceRequestMiddleware.php
+++ b/src/Support/HttpServer/TraceRequestMiddleware.php
@@ -43,11 +43,6 @@ class TraceRequestMiddleware
             }
 
             return $response;
-        } catch (\Throwable $exception) {
-            $span->recordException($exception)
-                ->setStatus(StatusCode::STATUS_ERROR);
-
-            throw $exception;
         } finally {
             $scope->detach();
             $span->end();

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -87,4 +87,14 @@ class Tracer
             $field => $traceId,
         ]);
     }
+
+    public function terminateActiveSpansUpToRoot(?SpanInterface $root = null): void
+    {
+        $span = $this->activeSpan();
+        while ($span->isRecording() && $span !== $root) {
+            $this->activeScope()?->detach();
+            $span->end();
+            $span = $this->activeSpan();
+        }
+    }
 }

--- a/tests/Instrumentation/RedisInstrumentationTest.php
+++ b/tests/Instrumentation/RedisInstrumentationTest.php
@@ -22,9 +22,11 @@ test('redis span is not created when trace is not started', function () {
 
 it('can watch a redis call', function (string $client) {
     config()->set('database.redis.client', $client);
+    $connection = 'default';
+    $config = config("database.redis.$connection");
 
-    withRootSpan(function () {
-        \Illuminate\Support\Facades\Redis::connection('default')->get('test');
+    withRootSpan(function () use ($connection) {
+        \Illuminate\Support\Facades\Redis::connection($connection)->get('test');
     });
 
     $span = getRecordedSpans()->first();
@@ -36,7 +38,7 @@ it('can watch a redis call', function (string $client) {
         ->getAttributes()->toArray()->toBe([
             'db.system.name' => 'redis',
             'db.query.text' => 'get test',
-            'server.address' => '127.0.0.1',
+            'server.address' => $config['host'],
         ])
         ->hasEnded()->toBeTrue()
         ->getEndEpochNanos()->toBeLessThan(Clock::getDefault()->now());

--- a/tests/Instrumentation/RedisInstrumentationTest.php
+++ b/tests/Instrumentation/RedisInstrumentationTest.php
@@ -23,7 +23,7 @@ test('redis span is not created when trace is not started', function () {
 
 it('can watch a redis call', function (string $client) {
     config()->set('database.redis.client', $client);
-    $config = config("database.redis.default");
+    $config = config('database.redis.default');
 
     withRootSpan(fn () => Redis::connection('default')->get('test'));
 

--- a/tests/Instrumentation/RedisInstrumentationTest.php
+++ b/tests/Instrumentation/RedisInstrumentationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Redis;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Instrumentation\RedisInstrumentation;
 use OpenTelemetry\API\Common\Time\Clock;
@@ -13,7 +14,7 @@ beforeEach(function () {
 test('redis span is not created when trace is not started', function () {
     expect(Tracer::traceStarted())->toBeFalse();
 
-    \Illuminate\Support\Facades\Redis::connection('default')->get('test');
+    Redis::connection('default')->get('test');
 
     $span = getRecordedSpans()->first();
 
@@ -22,12 +23,9 @@ test('redis span is not created when trace is not started', function () {
 
 it('can watch a redis call', function (string $client) {
     config()->set('database.redis.client', $client);
-    $connection = 'default';
-    $config = config("database.redis.$connection");
+    $config = config("database.redis.default");
 
-    withRootSpan(function () use ($connection) {
-        \Illuminate\Support\Facades\Redis::connection($connection)->get('test');
-    });
+    withRootSpan(fn () => Redis::connection('default')->get('test'));
 
     $span = getRecordedSpans()->first();
 

--- a/tests/Support/KeepsuitException.php
+++ b/tests/Support/KeepsuitException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Tests\Support;
+
+use Exception;
+
+class KeepsuitException extends Exception
+{
+    public static function create(): self
+    {
+        return new self('Keepsuit Exception thrown!');
+    }
+}

--- a/tests/Support/TestException.php
+++ b/tests/Support/TestException.php
@@ -4,10 +4,10 @@ namespace Keepsuit\LaravelOpenTelemetry\Tests\Support;
 
 use Exception;
 
-class KeepsuitException extends Exception
+class TestException extends Exception
 {
     public static function create(): self
     {
-        return new self('Keepsuit Exception thrown!');
+        return new self('Exception thrown!');
     }
 }


### PR DESCRIPTION
**Fix for:** https://github.com/keepsuit/laravel-opentelemetry/issues/43

This change introduces support for reporting exceptions to OpenTelemetry and marking span statuses as `error` by leveraging Laravel’s built-in exception handler. This approach delegates control of exception reporting to the developer, consistent with standard Laravel practices.

Additionally, I've added Docker support, as I don’t use a local PHP installation and work entirely in a Dockerized environment. To simplify development, I included a `Makefile` and a short description in the README on how to set up the environment.

I noticed some Redis-related tests are failing due to the lack of a Redis instance. Since I don’t have one running locally, I recommend adding a `docker-compose.yaml` file with a Redis service for a smoother development experience.

Let me know what you think! 😊