### PR TITLE
Preserve root path in HTTP excluded paths

### DIFF
--- a/src/Instrumentation/HttpServerInstrumentation.php
+++ b/src/Instrumentation/HttpServerInstrumentation.php
@@ -45,7 +45,7 @@ class HttpServerInstrumentation implements Instrumentation
     public function register(array $options): void
     {
         static::$excludedPaths = array_map(
-            fn (string $path) => ltrim($path, '/'),
+            fn (string $path) => $path === '/' ? '/' : ltrim($path, '/'),
             Arr::get($options, 'excluded_paths', []),
         );
 

--- a/tests/Instrumentation/HttpServerInstrumentationTest.php
+++ b/tests/Instrumentation/HttpServerInstrumentationTest.php
@@ -271,6 +271,27 @@ it('skip tracing for excluded paths', function () {
         ->toBeNull();
 });
 
+it('skip tracing for excluded root path', function () {
+    Route::any('/', fn () => 'ok');
+
+    registerInstrumentation(HttpServerInstrumentation::class, [
+        'excluded_paths' => [
+            '/',
+        ],
+    ]);
+
+    $response = $this->get('/');
+
+    $response->assertOk();
+
+    $spans = getRecordedSpans();
+
+    $serverSpan = $spans->firstWhere(fn (ImmutableSpan $span) => $span->getKind() === SpanKind::KIND_SERVER);
+
+    expect($serverSpan)
+        ->toBeNull();
+});
+
 it('trace allowed request headers', function () {
     registerInstrumentation(HttpServerInstrumentation::class, [
         'allowed_headers' => [


### PR DESCRIPTION
## Summary
- Preserve `/` when normalizing `excluded_paths` so the HTTP instrumentation can correctly skip tracing requests to the root route.
- Add a regression test covering exclusion of the root path.

## Testing
- Not run (not requested).
- Added a test that registers `excluded_paths: ['/']` and asserts no server span is recorded for a request to `/`.