### PR TITLE
Fix leaked producer span on sync queue driver

### DIFF
--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -100,14 +100,14 @@ class QueueInstrumentation implements Instrumentation
     protected function recordJobProcessing(): void
     {
         app('events')->listen(JobProcessing::class, function (JobProcessing $event) {
-              // The sync queue driver never dispatches JobQueued, so the producer span would otherwise leak and never be exported.
-              // Close any still-open producer span for this job before starting the consumer span. 
-              // For async drivers JobQueued has already ended/removed it, so this is a no-op.
-              $producerUuid = $event->job->uuid();
-              if ($producerUuid !== null && isset($this->activeSpans[$producerUuid])) {
-                  $this->activeSpans[$producerUuid]->end();
-                  unset($this->activeSpans[$producerUuid]);
-              }
+            // The sync queue driver never dispatches JobQueued, so the producer span would otherwise leak and never be exported.
+            // Close any still-open producer span for this job before starting the consumer span.
+            // For async drivers JobQueued has already ended/removed it, so this is a no-op.
+            $producerUuid = $event->job->uuid();
+            if ($producerUuid !== null && isset($this->activeSpans[$producerUuid])) {
+                $this->activeSpans[$producerUuid]->end();
+                unset($this->activeSpans[$producerUuid]);
+            }
 
             $context = Tracer::extractContextFromPropagationHeaders($event->job->payload());
 

--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -100,6 +100,15 @@ class QueueInstrumentation implements Instrumentation
     protected function recordJobProcessing(): void
     {
         app('events')->listen(JobProcessing::class, function (JobProcessing $event) {
+              // The sync queue driver never dispatches JobQueued, so the producer span would otherwise leak and never be exported.
+              // Close any still-open producer span for this job before starting the consumer span. 
+              // For async drivers JobQueued has already ended/removed it, so this is a no-op.
+              $producerUuid = $event->job->uuid();
+              if ($producerUuid !== null && isset($this->activeSpans[$producerUuid])) {
+                  $this->activeSpans[$producerUuid]->end();
+                  unset($this->activeSpans[$producerUuid]);
+              }
+
             $context = Tracer::extractContextFromPropagationHeaders($event->job->payload());
 
             $span = Tracer::newSpan(sprintf('process %s', $event->job->getQueue()))

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -100,6 +100,42 @@ it('can trace queue jobs', function () {
         ]);
 });
 
+it('can trace sync queue jobs', function () {
+    config()->set('queue.default', 'sync');
+
+    withRootSpan(function () {
+        dispatch(new TestJob($this->valuestore));
+    });
+
+    $root = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'root');
+    $enqueueSpan = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'send default');
+    $processSpan = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE) === 'process');
+
+    assert($root instanceof ImmutableSpan);
+    assert($enqueueSpan instanceof ImmutableSpan);
+    assert($processSpan instanceof ImmutableSpan);
+
+    expect($enqueueSpan)
+        ->getParentSpanId()->toBe($root->getSpanId())
+        ->getAttributes()->toMatchArray([
+            MessagingIncubatingAttributes::MESSAGING_SYSTEM => 'sync',
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE => 'send',
+            MessagingIncubatingAttributes::MESSAGING_MESSAGE_ID => $this->valuestore->get('uuid'),
+            MessagingIncubatingAttributes::MESSAGING_DESTINATION_NAME => 'default',
+            'messaging.message.job_name' => TestJob::class,
+        ]);
+
+    expect($processSpan)
+        ->getTraceId()->toBe($enqueueSpan->getTraceId())
+        ->getParentSpanId()->toBe($enqueueSpan->getSpanId())
+        ->getAttributes()->toMatchArray([
+            MessagingIncubatingAttributes::MESSAGING_SYSTEM => 'sync',
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE => 'process',
+            MessagingIncubatingAttributes::MESSAGING_MESSAGE_ID => $this->valuestore->get('uuid'),
+            'messaging.message.job_name' => TestJob::class,
+        ]);
+});
+
 it('can trace queue jobs dispatched after commit', function () {
     withRootSpan(function () {
         DB::transaction(function () {


### PR DESCRIPTION
### Problem
  
On the `sync` driver, the PRODUCER `send <queue>` span opened in `createPayloadUsing()` is never ended, because `SyncQueue::push()` builds the payload but never dispatches `JobQueued` (it bypasses `Queue::enqueueUsing()`). The span is never exported, so its `process <queue>` child and grandchildren show up orphaned under a missing parent.

### Fix
  
End any producer span still tracked in `$activeSpans` when the matching job starts processing. For the sync driver, `JobProcessing` fires right after the payload is built (same process), so the span is closed and exported with an accurate, near-zero "send" duration. For async drivers this branch never triggers: `JobQueued` already ended and removed the span at enqueue time, and processing runs in a separate worker process where `$activeSpans` doesn't contain it.

This keeps producer/consumer spans intact for all drivers and adds no driver-specific branching.

**Repro:** set `QUEUE_CONNECTION=sync` (or use `dispatch_sync`) with queue instrumentation enabled; the `send` span is absent and `process` appears orphaned.