### PR TITLE
Fix queue span cleanup across job retries

### DIFF
--- a/src/Instrumentation/QueueInstrumentation.php
+++ b/src/Instrumentation/QueueInstrumentation.php
@@ -2,6 +2,7 @@
 
 namespace Keepsuit\LaravelOpenTelemetry\Instrumentation;
 
+use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
@@ -133,27 +134,38 @@ class QueueInstrumentation implements Instrumentation
         });
 
         app('events')->listen(JobProcessed::class, function (JobProcessed $event) {
-            $scope = Tracer::activeScope();
-            $span = Tracer::activeSpan();
-
-            $scope?->detach();
-            $span->end();
+            $this->finishActiveJobSpan();
         });
 
         app('events')->listen(JobFailed::class, function (JobFailed $event) {
-            $scope = Tracer::activeScope();
-            $span = Tracer::activeSpan();
+            $this->finishActiveJobSpan($event->exception);
+        });
 
-            $span->recordException($event->exception)
-                ->setStatus(StatusCode::STATUS_ERROR);
+        app('events')->listen(JobExceptionOccurred::class, function (JobExceptionOccurred $event) {
+            if ($event->job->hasFailed()) {
+                return;
+            }
 
-            $scope?->detach();
-            $span->end();
+            $this->finishActiveJobSpan($event->exception);
         });
     }
 
     protected function connectionDriver(string $connection): string
     {
         return config(sprintf('queue.connections.%s.driver', $connection), 'unknown');
+    }
+
+    protected function finishActiveJobSpan(?Throwable $exception = null): void
+    {
+        $scope = Tracer::activeScope();
+        $span = Tracer::activeSpan();
+
+        if ($exception !== null) {
+            $span->recordException($exception)
+                ->setStatus(StatusCode::STATUS_ERROR);
+        }
+
+        $scope?->detach();
+        $span->end();
     }
 }

--- a/tests/Instrumentation/.gitignore
+++ b/tests/Instrumentation/.gitignore
@@ -1,1 +1,3 @@
 testJob.json
+followingTestJob.json
+retryingTestJob.json

--- a/tests/Instrumentation/QueueInstrumentationTest.php
+++ b/tests/Instrumentation/QueueInstrumentationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
 use Keepsuit\LaravelOpenTelemetry\Instrumentation\QueryInstrumentation;
 use Keepsuit\LaravelOpenTelemetry\Instrumentation\QueueInstrumentation;
+use Keepsuit\LaravelOpenTelemetry\Tests\Support\RetryingTestJob;
 use Keepsuit\LaravelOpenTelemetry\Tests\Support\TestJob;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\ImmutableSpan;
@@ -37,9 +37,7 @@ test('job process span is created without parent', function () {
 
     dispatch(new TestJob($this->valuestore));
 
-    Artisan::call('queue:work', [
-        '--once' => true,
-    ]);
+    executeQueueWork();
 
     $root = getRecordedSpans()->last();
 
@@ -53,9 +51,7 @@ it('can trace queue jobs', function () {
         dispatch(new TestJob($this->valuestore));
     });
 
-    Artisan::call('queue:work', [
-        '--once' => true,
-    ]);
+    executeQueueWork();
 
     $root = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'root');
     $enqueueSpan = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'send default');
@@ -145,9 +141,7 @@ it('can trace queue jobs dispatched after commit', function () {
         });
     });
 
-    Artisan::call('queue:work', [
-        '--once' => true,
-    ]);
+    executeQueueWork();
 
     $root = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'root');
     $sqlSpan = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'SELECT');
@@ -180,11 +174,7 @@ it('can trace queue failing jobs', function () {
         dispatch(new TestJob($this->valuestore, fail: true));
     });
 
-    Artisan::call('queue:work', [
-        '--once' => true,
-        '--tries' => 1,
-        '--timeout' => 3,
-    ]);
+    executeQueueWork();
 
     $root = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'root');
     $enqueueSpan = getRecordedSpans()->first(fn (ImmutableSpan $span) => $span->getName() === 'send default');
@@ -224,4 +214,56 @@ it('can trace queue failing jobs', function () {
             MessagingIncubatingAttributes::MESSAGING_DESTINATION_NAME => 'default',
             'messaging.message.job_name' => TestJob::class,
         ]);
+});
+
+it('does not leak the active consumer span between retry attempts and later jobs', function () {
+    $retryingJobStore = Valuestore::make(__DIR__.'/retryingTestJob.json')->flush();
+    $followingJobStore = Valuestore::make(__DIR__.'/followingTestJob.json')->flush();
+
+    // First attempt fails, the second succeed
+    dispatch(new RetryingTestJob($retryingJobStore));
+
+    executeQueueWork();
+
+    dispatch(new TestJob($followingJobStore));
+
+    executeQueueWork();
+    executeQueueWork();
+
+    $retryTraceIds = $retryingJobStore->get('traceIdInJobAttempts');
+    $retryUuid = $retryingJobStore->get('uuid');
+    $followingUuid = $followingJobStore->get('uuid');
+
+    $processSpans = getRecordedSpans()
+        ->filter(fn (ImmutableSpan $span) => $span->getName() === 'process default')
+        ->values();
+
+    $retryProcessSpans = $processSpans
+        ->filter(fn (ImmutableSpan $span) => $span->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_MESSAGE_ID) === $retryUuid)
+        ->values();
+
+    $followingProcessSpan = $processSpans
+        ->first(fn (ImmutableSpan $span) => $span->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_MESSAGE_ID) === $followingUuid);
+
+    expect($retryTraceIds)
+        ->toHaveCount(2)
+        ->and($retryTraceIds[0])->not->toBeNull()
+        ->and($retryTraceIds[1])->not->toBeNull()
+        ->and($retryTraceIds[1])->not->toBe($retryTraceIds[0]);
+
+    expect($retryingJobStore->get('traceparentInJobAttempts'))
+        ->toBe([null, null]);
+
+    expect($retryProcessSpans)
+        ->toHaveCount(2)
+        ->and($retryProcessSpans[0]->getStatus()->getCode())->toBe(StatusCode::STATUS_ERROR)
+        ->and($retryProcessSpans[0]->getEvents())->toHaveCount(1)
+        ->and($retryProcessSpans[1]->getStatus()->getCode())->toBe(StatusCode::STATUS_UNSET);
+
+    expect($followingProcessSpan)
+        ->not->toBeNull()
+        ->getTraceId()->not->toBe($retryTraceIds[1]);
+
+    $retryingJobStore->flush();
+    $followingJobStore->flush();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -114,3 +114,11 @@ function registerInstrumentation(string $instrumentation, array $options = []): 
 
     app()->make($instrumentation)->register($options);
 }
+
+function executeQueueWork(): void
+{
+    Artisan::call('queue:work', [
+        '--once' => true,
+        '--timeout' => 1,
+    ]);
+}

--- a/tests/Support/RetryingTestJob.php
+++ b/tests/Support/RetryingTestJob.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Keepsuit\LaravelOpenTelemetry\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Keepsuit\LaravelOpenTelemetry\Facades\Tracer;
+use Spatie\Valuestore\Valuestore;
+
+class RetryingTestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 2;
+
+    public function __construct(
+        protected Valuestore $valuestore
+    ) {}
+
+    public function handle(): void
+    {
+        $attempt = $this->job->attempts();
+
+        $this->valuestore->put('uuid', $this->job->uuid());
+        $this->valuestore->put('traceparentInJobAttempts', [
+            ...$this->valuestore->get('traceparentInJobAttempts', []),
+            $this->job->payload()['traceparent'] ?? null,
+        ]);
+        $this->valuestore->put('traceIdInJobAttempts', [
+            ...$this->valuestore->get('traceIdInJobAttempts', []),
+            Tracer::traceId(),
+        ]);
+        $this->valuestore->put('logContextInJobAttempts', [
+            ...$this->valuestore->get('logContextInJobAttempts', []),
+            Log::sharedContext(),
+        ]);
+
+        if ($attempt === 1) {
+            throw new \Exception('Job failed on first attempt');
+        }
+    }
+}


### PR DESCRIPTION
Fix #89 

## Summary
- Ensure the active queue consumer span is always detached and ended after job processing, including retry paths.
- Handle `JobExceptionOccurred` separately so failed attempts record the exception without leaking span context into later attempts.
- Add regression coverage for a retrying job followed by another job to verify trace context does not leak between attempts.
- Introduce a shared `executeQueueWork()` test helper and new retrying test job fixture for the scenario.

## Testing
- Run the queue instrumentation test suite, including the new retry leakage regression.
- Verify the failing first attempt records an error span event and the retry succeeds with a fresh span.
- Verify a later job gets a different trace ID than the retried job attempt.
- Not run